### PR TITLE
fix:multipart boundary for multipart parsing

### DIFF
--- a/src/components/shared/EstEnrollModal.tsx
+++ b/src/components/shared/EstEnrollModal.tsx
@@ -337,10 +337,10 @@ export const EstEnrollModal: React.FC<EstEnrollModalProps> = ({ isOpen, onOpenCh
     
     const serverKeygenParseCommands = [
         `# 3. Extract Private Key`,
-        `awk '/Content-Type: application\\/pkcs8/{f=1; next} /--boundary/{f=0} f' ${finalDeviceId}.multipart > key.b64`,
+        `awk '/Content-Type: application\\/pkcs8/{f=1; next} /--estServerLamassuBoundary/{f=0} f' ${finalDeviceId}.multipart > key.b64`,
         `openssl base64 -d -in key.b64 | openssl pkcs8 -inform DER -outform PEM -out ${finalDeviceId}.key`,
         `\n# 4. Extract Certificate`,
-        `awk '/Content-Type: application\\/pkcs7-mime/{f=1; next} /--boundary/{f=0} f' ${finalDeviceId}.multipart > cert.b64`,
+        `awk '/Content-Type: application\\/pkcs7-mime/{f=1; next} /--estServerLamassuBoundary/{f=0} f' ${finalDeviceId}.multipart > cert.b64`,
         `openssl base64 -d -in cert.b64 | openssl pkcs7 -inform DER -print_certs -out ${finalDeviceId}.crt`,
         `\n# 5. Verify the new certificate`,
         `openssl x509 -text -noout -in ${finalDeviceId}.crt`


### PR DESCRIPTION
This pull request updates the `EstEnrollModal` component to improve parsing logic for extracting private keys and certificates. The changes replace the generic boundary identifier with a specific one (`--estServerLamassuBoundary`) to enhance accuracy during the extraction process.

Parsing logic improvements:

* [`src/components/shared/EstEnrollModal.tsx`](diffhunk://#diff-fe7673d4c411b7ea0a48937a56cc470562c2f91adab57193cc98f52a2c38869dL340-R343): Updated the `awk` commands in `serverKeygenParseCommands` to use `--estServerLamassuBoundary` instead of `--boundary` for extracting private keys and certificates. This ensures compatibility with the specific server configuration.