### PR TITLE
Remove Dashboard title from home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ import { SummaryStatsCard } from '@/components/home/SummaryStatsCard';
 import type { CA } from '@/lib/ca-data';
 import { fetchAndProcessCAs, fetchCryptoEngines, fetchCaStatsSummary } from '@/lib/ca-data';
 import { useAuth } from '@/contexts/AuthContext';
-import { Loader2, AlertTriangle, RefreshCw, HomeIcon } from 'lucide-react';
+import { Loader2, AlertTriangle, RefreshCw } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -144,11 +144,7 @@ export default function HomePage() {
 
   return (
     <div className="w-full space-y-8">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center space-x-3">
-            <HomeIcon className="h-8 w-8 text-primary" />
-            <h1 className="text-2xl font-headline font-semibold">Dashboard</h1>
-        </div>
+      <div className="flex items-center justify-end">
         <Button onClick={loadInitialData} variant="outline" disabled={isReloading}>
             <RefreshCw className={cn("mr-2 h-4 w-4", isReloading && "animate-spin")} /> Refresh All
         </Button>


### PR DESCRIPTION
This pull request simplifies the `HomePage` component by removing redundant UI elements and streamlining imports in `src/app/page.tsx`. The most notable changes include removing the `HomeIcon` and associated dashboard title and adjusting the layout to focus on the "Refresh All" button.

### UI Simplifications:

* Removed the `HomeIcon` and dashboard title from the header section, simplifying the visual layout of the homepage. (`src/app/page.tsx`, [src/app/page.tsxL147-R147](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL147-R147))

### Code Cleanup:

* Removed the unused `HomeIcon` import from `lucide-react`, reducing unnecessary dependencies. (`src/app/page.tsx`, [src/app/page.tsxL12-R12](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL12-R12))

<img width="1678" height="890" alt="image" src="https://github.com/user-attachments/assets/3023257a-2d0a-459d-bc75-2301df30e36b" />
