### PR TITLE
feat: add filter by CA to the certificates list

### DIFF
--- a/src/app/certificates/page.tsx
+++ b/src/app/certificates/page.tsx
@@ -77,6 +77,7 @@ export default function CertificatesPage() {
     searchTerm, setSearchTerm,
     searchField, setSearchField,
     statusFilter, setStatusFilter,
+    caIdFilter, setCaIdFilter,
     sortConfig, requestSort,
     currentPageIndex,
     nextTokenFromApi,
@@ -205,6 +206,17 @@ export default function CertificatesPage() {
     { label: 'Expired', value: 'EXPIRED' },
     { label: 'Revoked', value: 'REVOKED' },
   ];
+  
+  // Flatten CAs for the dropdown selector
+  const flattenedCaList = (function flatten(cas: CA[]): CA[] {
+      return cas.reduce((acc, ca) => {
+          acc.push(ca);
+          if (ca.children) {
+              acc.push(...flatten(ca.children));
+          }
+          return acc;
+      }, [] as CA[]);
+  })(allCAs);
 
   return (
     <div className="w-full space-y-6 pb-8">
@@ -223,7 +235,7 @@ export default function CertificatesPage() {
         </div>
       </div>
 
-       <div className="grid grid-cols-1 md:grid-cols-3 gap-3 items-end">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-3 items-end">
         <div className="relative col-span-1 md:col-span-1">
             <Label htmlFor="certSearchTermInput">Search Term</Label>
             <Search className="absolute left-3 top-[calc(50%+6px)] -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
@@ -246,6 +258,20 @@ export default function CertificatesPage() {
                 <SelectContent>
                     <SelectItem value="commonName">Common Name</SelectItem>
                     <SelectItem value="serialNumber">Serial Number</SelectItem>
+                </SelectContent>
+            </Select>
+        </div>
+        <div className="col-span-1 md:col-span-1">
+            <Label htmlFor="certCaFilterSelect">CA Issuer</Label>
+            <Select value={caIdFilter || 'ALL'} onValueChange={(value) => setCaIdFilter(value === 'ALL' ? null : value)} disabled={isLoadingApi || authLoading || isLoadingCAs}>
+                <SelectTrigger id="certCaFilterSelect" className="w-full mt-1">
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem value="ALL">All Issuers</SelectItem>
+                    {flattenedCaList.map(ca => (
+                        <SelectItem key={ca.id} value={ca.id}>{ca.name}</SelectItem>
+                    ))}
                 </SelectContent>
             </Select>
         </div>

--- a/src/app/certificates/page.tsx
+++ b/src/app/certificates/page.tsx
@@ -90,6 +90,7 @@ export default function CertificatesPage() {
   const [selectedCertificate, setSelectedCertificate] = useState<CertificateData | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isCaSelectorOpen, setIsCaSelectorOpen] = useState(false);
+  const [caSelectorMode, setCaSelectorMode] = useState<'issue' | 'filter'>('filter');
 
   // CA and Engine data is still fetched here as it's a page-level concern
   const [allCAs, setAllCAs] = useState<CA[]>([]);
@@ -150,6 +151,11 @@ export default function CertificatesPage() {
   useEffect(() => {
     loadPageDependencies();
   }, [loadPageDependencies]);
+  
+  const handleOpenCaSelector = (mode: 'issue' | 'filter') => {
+    setCaSelectorMode(mode);
+    setIsCaSelectorOpen(true);
+  };
 
   const handleCaSelectedForIssuance = (ca: CA) => {
     if (ca.status !== 'active' || new Date(ca.expires) < new Date()) {
@@ -228,7 +234,7 @@ export default function CertificatesPage() {
             <Button onClick={refreshCertificates} variant="outline" disabled={isLoadingApi && certificates.length > 0}>
                 <RefreshCw className={cn("mr-2 h-4 w-4", isLoadingApi && certificates.length > 0 && "animate-spin")} /> Refresh List
             </Button>
-            <Button onClick={() => setIsCaSelectorOpen(true)} variant="default">
+            <Button onClick={() => handleOpenCaSelector('issue')} variant="default">
                 <PlusCircle className="mr-2 h-4 w-4" /> Issue Certificate
             </Button>
         </div>
@@ -267,7 +273,7 @@ export default function CertificatesPage() {
                     id="ca-filter-button"
                     variant="outline"
                     className="w-full justify-start text-left font-normal"
-                    onClick={() => setIsCaSelectorOpen(true)}
+                    onClick={() => handleOpenCaSelector('filter')}
                     disabled={isLoadingApi || authLoading || isLoadingCAs}
                 >
                     {selectedCaForFilter ? selectedCaForFilter.name : 'All Issuers'}
@@ -370,13 +376,15 @@ export default function CertificatesPage() {
       <CaSelectorModal 
         isOpen={isCaSelectorOpen} 
         onOpenChange={setIsCaSelectorOpen} 
-        title="Select an Issuer" 
-        description={caIdFilter ? "Choose a new Certification Authority to filter the certificate list." : "Choose the Certification Authority that will issue the new certificate."}
+        title={caSelectorMode === 'issue' ? "Select an Issuer" : "Filter by CA Issuer"}
+        description={caSelectorMode === 'issue' 
+            ? "Choose the Certification Authority that will issue the new certificate." 
+            : "Choose a Certification Authority to filter the certificate list."}
         availableCAs={allCAs} 
         isLoadingCAs={isLoadingCAs} 
         errorCAs={errorCAs} 
         loadCAsAction={loadPageDependencies} 
-        onCaSelected={caIdFilter ? handleCaSelectedForFilter : handleCaSelectedForIssuance} 
+        onCaSelected={caSelectorMode === 'issue' ? handleCaSelectedForIssuance : handleCaSelectedForFilter}
         isAuthLoading={authLoading} 
         allCryptoEngines={allCryptoEngines} 
       />

--- a/src/hooks/usePaginatedCertificateFetcher.ts
+++ b/src/hooks/usePaginatedCertificateFetcher.ts
@@ -41,6 +41,7 @@ export function usePaginatedCertificateFetcher({ caId = null, initialPageSize = 
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
   const [searchField, setSearchField] = useState<'commonName' | 'serialNumber'>('commonName');
   const [statusFilter, setStatusFilter] = useState<ApiStatusFilterValue>('ALL');
+  const [caIdFilter, setCaIdFilter] = useState<string | null>(caId);
   const [sortConfig, setSortConfig] = useState<CertSortConfig | null>({ column: 'validFrom', direction: 'desc' });
   
   // Ref to track if this is the very first load to prevent extra renders
@@ -119,7 +120,7 @@ export function usePaginatedCertificateFetcher({ caId = null, initialPageSize = 
             
             const result = await fetchIssuedCertificates({
                 accessToken: user.access_token,
-                forCaId: caId ?? undefined,
+                forCaId: caIdFilter ?? undefined, // Use the new caIdFilter state
                 apiQueryString: apiParams.toString(),
             });
             setCertificates(result.certificates);
@@ -152,7 +153,7 @@ export function usePaginatedCertificateFetcher({ caId = null, initialPageSize = 
         setCurrentPageIndex(0);
         setBookmarkStack([null]);
     }
-  }, [pageSize, debouncedSearchTerm, searchField, statusFilter, sortConfig]);
+  }, [pageSize, debouncedSearchTerm, searchField, statusFilter, sortConfig, caIdFilter]);
 
 
   const handleNextPage = () => {
@@ -200,6 +201,7 @@ export function usePaginatedCertificateFetcher({ caId = null, initialPageSize = 
     searchTerm, setSearchTerm,
     searchField, setSearchField,
     statusFilter, setStatusFilter,
+    caIdFilter, setCaIdFilter,
     sortConfig, requestSort,
     currentPageIndex,
     nextTokenFromApi,


### PR DESCRIPTION
This pull request adds a new feature to filter certificates by Certification Authority (CA) issuer on the certificates page. It introduces a CA filter button, manages CA selection for both issuing and filtering, and ensures the CA filter is integrated into the certificate fetching logic. The changes also improve the user experience by allowing users to clear the CA filter and by updating the CA selector modal to handle both issuing and filtering modes.

**Certificate Filtering and UI Enhancements:**

* Added a "CA Issuer" filter button to the certificates page, allowing users to filter the certificate list by a selected Certification Authority. The button displays the selected CA or "All Issuers" and includes a clear ("X") button to remove the filter. (`src/app/certificates/page.tsx`)
* Refactored CA selector modal logic to support two modes: issuing a certificate and filtering by CA issuer. The modal's title, description, and callback are now dynamic based on the current mode. (`src/app/certificates/page.tsx`) [[1]](diffhunk://#diff-559abd4f98e6f33f05a0a0145038cb31e8522a1bc24982b79492e50ed694ee67R93) [[2]](diffhunk://#diff-559abd4f98e6f33f05a0a0145038cb31e8522a1bc24982b79492e50ed694ee67R155-R159) [[3]](diffhunk://#diff-559abd4f98e6f33f05a0a0145038cb31e8522a1bc24982b79492e50ed694ee67R186-R195) [[4]](diffhunk://#diff-559abd4f98e6f33f05a0a0145038cb31e8522a1bc24982b79492e50ed694ee67L334-R390)
* Updated the layout to accommodate the new CA filter in the filter grid. (`src/app/certificates/page.tsx`)

**Certificate Fetching Logic:**

* Integrated the CA filter (`caIdFilter`) into the paginated certificate fetching hook and ensured that changing the filter triggers a new fetch. (`src/hooks/usePaginatedCertificateFetcher.ts`) [[1]](diffhunk://#diff-ac6c1edcb797cca85e1038f31c2639999af25110496e86a65b0f7b564e7e0270R44) [[2]](diffhunk://#diff-ac6c1edcb797cca85e1038f31c2639999af25110496e86a65b0f7b564e7e0270L122-R123) [[3]](diffhunk://#diff-ac6c1edcb797cca85e1038f31c2639999af25110496e86a65b0f7b564e7e0270L155-R156) [[4]](diffhunk://#diff-ac6c1edcb797cca85e1038f31c2639999af25110496e86a65b0f7b564e7e0270R204)

**Supporting Code Updates:**

* Imported necessary helpers and icons to support the new filter and modal logic. (`src/app/certificates/page.tsx`)