### PR TITLE
fix: certificate revocation actions

### DIFF
--- a/src/app/certificates/details/CertificateDetailsClient.tsx
+++ b/src/app/certificates/details/CertificateDetailsClient.tsx
@@ -119,9 +119,11 @@ export default function CertificateDetailsClient() { // Renamed component
     setErrorCert(null);
     try {
       // Use a specific filter to fetch only the requested certificate by its serial number.
+      // The API expects the serial number with hyphens instead of colons.
+      const apiFormattedSerialNumber = certificateId.replace(/:/g, '-');
       const { certificates: certList } = await fetchIssuedCertificates({ 
           accessToken: user.access_token, 
-          apiQueryString: `filter=serial_number[equal]${certificateId}&page_size=1`
+          apiQueryString: `filter=serial_number[equal]${apiFormattedSerialNumber}&page_size=1`
       });
       const foundCert = certList.length > 0 ? certList[0] : null;
       

--- a/src/lib/issued-certificate-data.ts
+++ b/src/lib/issued-certificate-data.ts
@@ -204,7 +204,10 @@ export async function updateCertificateStatus({
     body.revocation_reason = reason;
   }
   
-  const response = await fetch(`${CA_API_BASE_URL}/certificates/${serialNumber}/status`, {
+  // The API endpoint expects the serial number with hyphens instead of colons.
+  const apiFormattedSerialNumber = serialNumber.replace(/:/g, '-');
+  
+  const response = await fetch(`${CA_API_BASE_URL}/certificates/${apiFormattedSerialNumber}/status`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
@@ -226,7 +229,8 @@ export async function updateCertificateStatus({
 }
 
 export async function updateCertificateMetadata(serialNumber: string, metadata: object, accessToken: string): Promise<void> {
-  const response = await fetch(`${CA_API_BASE_URL}/certificates/${serialNumber}/metadata`, {
+  const apiFormattedSerialNumber = serialNumber.replace(/:/g, '-');
+  const response = await fetch(`${CA_API_BASE_URL}/certificates/${apiFormattedSerialNumber}/metadata`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
This pull request standardizes how certificate serial numbers are formatted when interacting with the API. Specifically, it ensures that serial numbers use hyphens instead of colons, as required by the backend. These changes help prevent issues when fetching or updating certificate data.

**Certificate serial number formatting:**

* Updated `CertificateDetailsClient` to replace colons with hyphens in `certificateId` before sending it in the API query string when fetching certificate details.
* Modified `updateCertificateStatus` in `issued-certificate-data.ts` to replace colons with hyphens in `serialNumber` before constructing the API endpoint URL.
* Modified `updateCertificateMetadata` in `issued-certificate-data.ts` to replace colons with hyphens in `serialNumber` before constructing the API endpoint URL.