### PR TITLE
fix: OCSP validation process

### DIFF
--- a/src/components/shared/OcspCheckModal.tsx
+++ b/src/components/shared/OcspCheckModal.tsx
@@ -16,7 +16,8 @@ import {
     setEngine,
     BasicOCSPResponse,
     Extension,
-    getRandomValues
+    getRandomValues,
+    SingleResponse
 } from "pkijs";
 import type { CertificateData } from '@/types/certificate';
 import type { CA } from '@/lib/ca-data';
@@ -233,17 +234,12 @@ export const OcspCheckModal: React.FC<OcspCheckModalProps> = ({ isOpen, onClose,
             }
             
             const basicResponse = new BasicOCSPResponse({ schema: asn1BasicResp.result });
-            const singleResponse = basicResponse.tbsResponseData.responses[0];
+            const singleResponse = new SingleResponse(basicResponse.tbsResponseData.responses[0]);
 
-            let responderId = "N/A";
-            if(basicResponse.tbsResponseData.responderID.byName) {
-                responderId = basicResponse.tbsResponseData.responderID.byName.typesAndValues.map((tv: any) => `${tv.type}=${tv.value.valueBlock.value}`).join(', ');
-            } else if (basicResponse.tbsResponseData.responderID.byKey) {
-                const keyHash = basicResponse.tbsResponseData.responderID.byKey.valueBlock.valueHex;
-                responderId = `KeyHash: ${Buffer.from(keyHash).toString('hex')}`;
-            }
+            const responderId = basicResponse.tbsResponseData.responderID.typesAndValues.map((tv: any) => `${tv.type}=${tv.value.valueBlock.value}`).join(', ');
+            
 
-            const certStatus = getCertStatusFromTag(singleResponse.certStatus.tag);
+            const certStatus = getCertStatusFromTag(singleResponse.certStatus.idBlock.tagNumber);
             let revokedInfo = {};
             if (certStatus === 'revoked' && singleResponse.certStatus.value?.revocationTime) {
                 revokedInfo = {


### PR DESCRIPTION
This pull request enhances the OCSP check modal and improves how certificate data is parsed and displayed. The main changes include extracting and displaying more detailed certificate information, especially for OCSP responses, and refactoring certificate parsing logic to centralize and reuse code.

**OCSP Modal Improvements:**

* Added a helper function `formatResponderId` and an `OID_MAP` to display human-readable OCSP responder IDs, supporting both byName and byKey formats. [[1]](diffhunk://#diff-6dcca8ef1f77104b69f19c54b93fa917c6bee416ebc004276d1de204404f9138R114-R129) [[2]](diffhunk://#diff-6dcca8ef1f77104b69f19c54b93fa917c6bee416ebc004276d1de204404f9138L236-R261)
* Updated the OCSP modal to use the new `SingleResponse` class and the improved responder ID formatting for better clarity. [[1]](diffhunk://#diff-6dcca8ef1f77104b69f19c54b93fa917c6bee416ebc004276d1de204404f9138L19-R23) [[2]](diffhunk://#diff-6dcca8ef1f77104b69f19c54b93fa917c6bee416ebc004276d1de204404f9138L236-R261)
* Imported additional UI components (`Table`, `ScrollArea`) and revocation reasons, preparing for richer OCSP result displays. [[1]](diffhunk://#diff-6dcca8ef1f77104b69f19c54b93fa917c6bee416ebc004276d1de204404f9138R10-R11) [[2]](diffhunk://#diff-6dcca8ef1f77104b69f19c54b93fa917c6bee416ebc004276d1de204404f9138R32)

**Certificate Data Parsing and Enrichment:**

* Refactored `transformApiIssuedCertificateToLocal` to use a new `parseCertificatePemDetails` function, centralizing PEM parsing and extracting additional fields such as OCSP URLs, SANs, key usages, and the SHA-256 fingerprint. [[1]](diffhunk://#diff-92fe25092e6753ad0e193b19a379be12645398363b93a6504dde017be515489cR3) [[2]](diffhunk://#diff-92fe25092e6753ad0e193b19a379be12645398363b93a6504dde017be515489cL89-R91)
* Populated the returned certificate object with parsed details (e.g., `sans`, `signatureAlgorithm`, `ocspUrls`, `keyUsage`), replacing previous placeholder values and redundant fingerprint generation logic.