### PR TITLE
feat: tag VA Roles option as devOnly and allow to produce an optimized build with the dev only action

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,41 @@ docker run -d -p 9002:80 \
 - Place theme assets under `/local/path/themes/<theme-name>/`.
 - `custom-theme.css` should import `/themes/<theme-name>/style.css` and can contain overrides.
 
+## Developer-only menu options
+
+Some navigation items in the app are marked as developer-only. These are controlled by a `devOnly: true` flag in the navigation configuration (see `src/app/layout.tsx` → `navigationConfig`). By default these items are hidden in production.
+
+How the toggle works
+- Developer-only items are shown when either:
+  - `process.env.NODE_ENV === 'development'` (local dev server), OR
+  - `process.env.NEXT_FORCE_DEV_OPTIONS` is set (truthy) at build/runtime.
+- Groups with all items filtered out are automatically hidden.
+
+Enable developer-only items
+- Local development
+  - Run the dev server (`npm run dev` / `pnpm dev`) — items appear automatically.
+- Forcing in non-development environments
+  - Set the environment variable `NEXT_FORCE_DEV_OPTIONS=1` (or another truthy value) and rebuild/restart the Next.js app.
+  - Example (Linux/macOS):
+    - In one-off run: `NEXT_FORCE_DEV_OPTIONS=1 npm start`
+    - Or export then start: `export NEXT_FORCE_DEV_OPTIONS=1 && npm run build && npm start`
+
+Adding a dev-only menu item
+- Example snippet from `src/app/layout.tsx`:
+```ts
+{
+  label: 'KMS',
+  items: [
+    { href: '/kms/keys', label: 'Keys', icon: KeyRound, devOnly: true }, // will be hidden unless dev mode / forced
+    { href: '/crypto-engines', label: 'Crypto Engines', icon: Cpu },
+  ],
+}
+```
+
+Notes
+- Because `process.env` checks are evaluated at runtime/build-time by Next.js, changing `NEXT_FORCE_DEV_OPTIONS` typically requires a rebuild or restart to take effect in production builds.
+- Use dev-only items for debugging, feature preview, or tools that should not be exposed
+
 ## License
 
 This project is licensed under the Mozilla Public License 2.0 (MPL 2.0). See the `LICENSE` file for more details.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -111,7 +111,7 @@ const navigationConfig: NavGroup[] = [
             { href: '/certificate-authorities', label: 'Certification Authorities', icon: Landmark },
             { href: '/signing-profiles', label: 'Issuance Profiles', icon: ScrollTextIcon, devOnly: true },
             { href: '/registration-authorities', label: 'Registration Authorities', icon: Users },
-            { href: '/verification-authorities', label: 'Verification Authorities', icon: ShieldCheck },
+            { href: '/verification-authorities', label: 'Verification Authorities', icon: ShieldCheck, devOnly: true },
         ],
     },
     {
@@ -348,12 +348,12 @@ const MainLayoutContent = ({ children }: { children: React.ReactNode }) => {
               <SidebarContent className="p-2">
                 <SidebarMenu>
                   {navigationConfig.map((group, groupIndex) => {
-                    if (group.devOnly && process.env.NODE_ENV !== 'development') {
+                    if (group.devOnly && !(process.env.NODE_ENV == 'development' ||  process.env.NEXT_FORCE_DEV_OPTIONS)) {
                         return null;
                     }
                     
                     const filteredItems = group.items.filter(item => 
-                        !(item.devOnly && process.env.NODE_ENV !== 'development')
+                        !(item.devOnly && !(process.env.NODE_ENV == 'development' ||  process.env.NEXT_FORCE_DEV_OPTIONS))
                     );
 
                     if (filteredItems.length === 0) {


### PR DESCRIPTION
This pull request introduces a developer-only menu option system to the application, allowing certain navigation items to be hidden or shown based on environment variables. The changes update both the documentation and the navigation logic to support this feature, making it easier to control visibility of debug or preview tools in the UI.

**Developer-only menu system:**

* Added documentation to `README.md` explaining how developer-only navigation items work, how to enable them, and how to add new ones via the `devOnly: true` flag in `src/app/layout.tsx`.
* Updated navigation configuration in `src/app/layout.tsx` to mark the "Verification Authorities" item as developer-only, so it's hidden unless in development mode or forced via environment variable.

**Navigation logic improvements:**

* Modified sidebar rendering logic in `src/app/layout.tsx` to filter out groups and items with `devOnly: true` unless in development mode or if `NEXT_FORCE_DEV_OPTIONS` is set, ensuring proper hiding/showing of developer-only items.