### PR TITLE
chore: add CI build workflow

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,25 @@
+name: CI Build
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build project
+        run: npm run build


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for continuous integration (CI) to automate the build process for the project. The workflow is triggered on pull requests and pushes to the `main` branch, ensuring that code changes are built and verified automatically.

Continuous integration workflow setup:

* Added a new workflow configuration file `.github/workflows/ci-build.yml` that defines a CI build process triggered on pull requests and pushes to `main`.
* Configured the workflow to use the latest Ubuntu runner, check out the repository code, set up Node.js version 20, install dependencies with `npm ci`, and build the project using `npm run build`.