### PR TITLE
feat: add force device update action at device when owner RA has an integration configured

### DIFF
--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -34,7 +34,7 @@ import Image from 'next/image';
 import AwsIcon from '../aws.svg';
 
 
-const IntegrationIcon: React.FC<{ type: DiscoveredIntegration['type'] }> = ({ type }) => {
+export const IntegrationIcon: React.FC<{ type: DiscoveredIntegration['type'] }> = ({ type }) => {
     switch (type) {
         case 'AWS_IOT_CORE':
             return <Image src={AwsIcon} alt="AWS IoT Core Icon" className="h-6 w-6" width={24} height={24} />;
@@ -263,4 +263,3 @@ export default function IntegrationsPage() {
     </>
   );
 }
-

--- a/src/components/shared/ForceUpdateModal.tsx
+++ b/src/components/shared/ForceUpdateModal.tsx
@@ -52,6 +52,16 @@ export const ForceUpdateModal: React.FC<ForceUpdateModalProps> = ({
 
   if (!device || !ra || !integration) return null;
 
+  const getConnectorId = (configKey: string) => {
+    const prefix = "lamassu.io/iot/";
+    if (configKey.startsWith(prefix)) {
+        return configKey.substring(prefix.length);
+    }
+    return configKey;
+  };
+  const connectorId = getConnectorId(integration.configKey);
+
+
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
@@ -69,14 +79,17 @@ export const ForceUpdateModal: React.FC<ForceUpdateModalProps> = ({
           <div className="p-3 border rounded-md bg-muted/50 space-y-2">
             <DetailItem label="Device ID" value={device.id} className="py-1" isMono/>
             <DetailItem label="Registration Authority" value={ra.name} className="py-1" />
-            <DetailItem 
-                label="Platform Integration" 
+            <DetailItem
+                label="Platform Integration"
                 value={
                     <div className="flex items-center gap-2">
                         <IntegrationIcon type={integration.type} />
-                        <span className="font-semibold">{integration.typeName}</span>
+                        <div className="flex flex-col">
+                            <span className="font-semibold">{integration.typeName}</span>
+                            <span className="text-xs text-muted-foreground font-mono">{connectorId}</span>
+                        </div>
                     </div>
-                } 
+                }
                 className="py-1"
             />
           </div>

--- a/src/components/shared/ForceUpdateModal.tsx
+++ b/src/components/shared/ForceUpdateModal.tsx
@@ -1,0 +1,134 @@
+
+'use client';
+
+import React, { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Loader2, Zap, AlertTriangle } from 'lucide-react';
+import { Switch } from '@/components/ui/switch';
+import type { ApiDevice } from '@/lib/devices-api';
+import type { ApiRaItem } from '@/lib/dms-api';
+import type { DiscoveredIntegration } from '@/lib/integrations-api';
+import { DetailItem } from './DetailItem';
+import { IntegrationIcon } from '@/app/integrations/page';
+
+interface ForceUpdateModalProps {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  onConfirm: (actions: string[]) => void;
+  device: ApiDevice | null;
+  ra: ApiRaItem | null;
+  integration: DiscoveredIntegration | null;
+  isUpdating: boolean;
+}
+
+export const ForceUpdateModal: React.FC<ForceUpdateModalProps> = ({
+  isOpen,
+  onOpenChange,
+  onConfirm,
+  device,
+  ra,
+  integration,
+  isUpdating,
+}) => {
+  const [updateTrustAnchor, setUpdateTrustAnchor] = useState(true);
+  const [updateCertificate, setUpdateCertificate] = useState(true);
+
+  const handleConfirm = () => {
+    const actions: string[] = [];
+    if (updateTrustAnchor) actions.push('UPDATE_TRUST_ANCHOR_LIST');
+    if (updateCertificate) actions.push('UPDATE_CERTIFICATE');
+    onConfirm(actions);
+  };
+
+  if (!device || !ra || !integration) return null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center">
+            <Zap className="mr-2 h-5 w-5 text-primary" />
+            Force Device Update
+          </DialogTitle>
+          <DialogDescription>
+            Trigger a manual update for the device's identity on the integrated platform.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="py-2 space-y-4">
+          <div className="p-3 border rounded-md bg-muted/50 space-y-2">
+            <DetailItem label="Device ID" value={device.id} className="py-1" isMono/>
+            <DetailItem label="Registration Authority" value={ra.name} className="py-1" />
+            <DetailItem 
+                label="Platform Integration" 
+                value={
+                    <div className="flex items-center gap-2">
+                        <IntegrationIcon type={integration.type} />
+                        <span className="font-semibold">{integration.typeName}</span>
+                    </div>
+                } 
+                className="py-1"
+            />
+          </div>
+
+          <div className="space-y-3">
+             <div className="flex items-center space-x-4 rounded-md border p-3">
+                <Switch 
+                    id="update-trust-anchor" 
+                    checked={updateTrustAnchor} 
+                    onCheckedChange={setUpdateTrustAnchor}
+                />
+                <Label htmlFor="update-trust-anchor" className="flex flex-col gap-0.5">
+                    <span className="font-semibold">Update Trust Anchor List</span>
+                    <span className="text-xs text-muted-foreground">Synchronizes the CA certificates on the platform with those configured in the RA.</span>
+                </Label>
+             </div>
+             <div className="flex items-center space-x-4 rounded-md border p-3">
+                <Switch 
+                    id="update-certificate" 
+                    checked={updateCertificate} 
+                    onCheckedChange={setUpdateCertificate}
+                />
+                <Label htmlFor="update-certificate" className="flex flex-col gap-0.5">
+                    <span className="font-semibold">Update Certificate</span>
+                     <span className="text-xs text-muted-foreground">Pushes the device's current active certificate to the platform.</span>
+                </Label>
+             </div>
+          </div>
+          
+           <Alert variant="warning">
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>Note</AlertTitle>
+              <AlertDescription>
+                This action sends an update request to the platform. The time to completion depends on the platform's processing queue.
+              </AlertDescription>
+            </Alert>
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={isUpdating}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleConfirm}
+            disabled={isUpdating || (!updateCertificate && !updateTrustAnchor)}
+          >
+            {isUpdating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Confirm Update
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/lib/devices-api.ts
+++ b/src/lib/devices-api.ts
@@ -1,3 +1,4 @@
+
 // src/lib/devices-api.ts
 import { DEV_MANAGER_API_BASE_URL, handleApiError } from './api-domains';
 
@@ -41,6 +42,13 @@ export interface DeviceStats {
         REVOKED: number;
     };
 }
+
+export interface PatchOperation {
+  op: "add" | "remove" | "replace";
+  path: string;
+  value?: any;
+}
+
 
 export async function fetchDevices(accessToken: string, params: URLSearchParams): Promise<ApiResponse> {
     const url = `${DEV_MANAGER_API_BASE_URL}/devices?${params.toString()}`;
@@ -90,3 +98,19 @@ export async function fetchDeviceStats(accessToken: string): Promise<DeviceStats
   });
   return handleApiError(response, 'Failed to fetch device stats');
 }
+
+export async function updateDeviceMetadata(deviceId: string, patchOperations: PatchOperation[], accessToken: string): Promise<void> {
+  const response = await fetch(`${DEV_MANAGER_API_BASE_URL}/devices/${deviceId}/metadata`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json-patch+json',
+      'Authorization': `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(patchOperations),
+  });
+
+  if (!response.ok) {
+    await handleApiError(response, 'Failed to update device metadata');
+  }
+}
+

--- a/src/lib/devices-api.ts
+++ b/src/lib/devices-api.ts
@@ -1,4 +1,5 @@
 
+
 // src/lib/devices-api.ts
 import { DEV_MANAGER_API_BASE_URL, handleApiError } from './api-domains';
 
@@ -101,16 +102,15 @@ export async function fetchDeviceStats(accessToken: string): Promise<DeviceStats
 
 export async function updateDeviceMetadata(deviceId: string, patchOperations: PatchOperation[], accessToken: string): Promise<void> {
   const response = await fetch(`${DEV_MANAGER_API_BASE_URL}/devices/${deviceId}/metadata`, {
-    method: 'PATCH',
+    method: 'PUT',
     headers: {
-      'Content-Type': 'application/json-patch+json',
+      'Content-Type': 'application/json',
       'Authorization': `Bearer ${accessToken}`,
     },
-    body: JSON.stringify(patchOperations),
+    body: JSON.stringify({ patches: patchOperations }),
   });
 
   if (!response.ok) {
     await handleApiError(response, 'Failed to update device metadata');
   }
 }
-

--- a/src/lib/dms-api.ts
+++ b/src/lib/dms-api.ts
@@ -223,11 +223,22 @@ export async function deleteRaIntegration(raId: string, integrationKey: string, 
     await createOrUpdateRa(payload, accessToken, true, raId);
 }
 
-export async function forceDeviceIdentityRefresh(dmsId: string, deviceId: string, accessToken: string): Promise<void> {
+interface ForceUpdateParams {
+    dmsId: string;
+    deviceId: string;
+    actions: string[];
+    accessToken: string;
+}
+
+export async function forceDeviceIdentityRefresh({ dmsId, deviceId, actions, accessToken }: ForceUpdateParams): Promise<void> {
     const url = `${DMS_MANAGER_API_BASE_URL}/dms/${dmsId}/devices/${deviceId}/refresh-identity`;
     const response = await fetch(url, {
         method: 'POST',
-        headers: { 'Authorization': `Bearer ${accessToken}` },
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ actions }),
     });
     if (!response.ok) {
         await handleApiError(response, 'Failed to force device identity refresh');

--- a/src/lib/dms-api.ts
+++ b/src/lib/dms-api.ts
@@ -1,5 +1,4 @@
 
-
 // src/lib/dms-api.ts
 
 import { DMS_MANAGER_API_BASE_URL, handleApiError } from './api-domains';
@@ -223,6 +222,7 @@ export async function deleteRaIntegration(raId: string, integrationKey: string, 
     await createOrUpdateRa(payload, accessToken, true, raId);
 }
 
+// THIS FUNCTION IS NOW DEPRECATED AND REPLACED BY A PATCH TO DEVICE METADATA
 interface ForceUpdateParams {
     dmsId: string;
     deviceId: string;

--- a/src/lib/dms-api.ts
+++ b/src/lib/dms-api.ts
@@ -1,4 +1,5 @@
 
+
 // src/lib/dms-api.ts
 
 import { DMS_MANAGER_API_BASE_URL, handleApiError } from './api-domains';
@@ -220,4 +221,15 @@ export async function deleteRaIntegration(raId: string, integrationKey: string, 
     
     // 5. Call the existing update function to save the modified RA
     await createOrUpdateRa(payload, accessToken, true, raId);
+}
+
+export async function forceDeviceIdentityRefresh(dmsId: string, deviceId: string, accessToken: string): Promise<void> {
+    const url = `${DMS_MANAGER_API_BASE_URL}/dms/${dmsId}/devices/${deviceId}/refresh-identity`;
+    const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${accessToken}` },
+    });
+    if (!response.ok) {
+        await handleApiError(response, 'Failed to force device identity refresh');
+    }
 }

--- a/src/lib/dms-api.ts
+++ b/src/lib/dms-api.ts
@@ -221,26 +221,3 @@ export async function deleteRaIntegration(raId: string, integrationKey: string, 
     // 5. Call the existing update function to save the modified RA
     await createOrUpdateRa(payload, accessToken, true, raId);
 }
-
-// THIS FUNCTION IS NOW DEPRECATED AND REPLACED BY A PATCH TO DEVICE METADATA
-interface ForceUpdateParams {
-    dmsId: string;
-    deviceId: string;
-    actions: string[];
-    accessToken: string;
-}
-
-export async function forceDeviceIdentityRefresh({ dmsId, deviceId, actions, accessToken }: ForceUpdateParams): Promise<void> {
-    const url = `${DMS_MANAGER_API_BASE_URL}/dms/${dmsId}/devices/${deviceId}/refresh-identity`;
-    const response = await fetch(url, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${accessToken}`,
-        },
-        body: JSON.stringify({ actions }),
-    });
-    if (!response.ok) {
-        await handleApiError(response, 'Failed to force device identity refresh');
-    }
-}


### PR DESCRIPTION
This pull request introduces a "Force Update" feature for device identities, allowing users to trigger manual updates for device certificates and trust anchors on integrated platforms (e.g., AWS IoT Core). The implementation includes UI changes, new modal components, integration data fetching, and backend API support for patching device metadata.

**New Feature: Force Update for Device Identities**
- Adds ability for users to manually trigger certificate and trust anchor updates for devices integrated with supported platforms.

**UI & Modal Integration**
- Added a "Force Update" button to the device details page, visible when an eligible integration is detected.
- Introduced a new `ForceUpdateModal` component that allows users to select which update actions to trigger, with clear descriptions and warnings.
- Modal is integrated into the device details page and properly handles loading and error states.

**API & Data Handling**
- Implemented `updateDeviceMetadata` and `PatchOperation` in `devices-api` for sending patch requests to update device metadata. [[1]](diffhunk://#diff-38cfbf7e0fac496ba4bd537928a915e506e572335336e982810036e653a19559R47-R53) [[2]](diffhunk://#diff-38cfbf7e0fac496ba4bd537928a915e506e572335336e982810036e653a19559R102-R116)
- Device details page now fetches integration and registration authority data when loading device details, and passes them to the modal. [[1]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cL28-R31) [[2]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cR93-R98) [[3]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cR119-R135) [[4]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cR163-R176)

**Component & Import Updates**
- Exported `IntegrationIcon` for reuse in the modal and other components.
- Updated imports to support new features and components. [[1]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cL11-R11) [[2]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cL28-R31)

**Device Update Logic**
- Added handler logic to construct and send patch operations based on user selections in the modal, with success/error feedback and automatic refresh.

These changes collectively enable a robust and user-friendly way for admins to force device identity updates on integrated platforms.