### PR TITLE
refactor: remove Docker image build steps from pre-release workflow

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -12,30 +12,9 @@ run-name: >-
         
 jobs:
   build_docker_image:
-    name: Release docker images
-    runs-on: ubuntu-latest
-    steps:        
-    - name: Login to Github Registry
-      uses: docker/login-action@v3
-      with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          
     - name: Checkout code
       uses: actions/checkout@v4
-    
-    - name: Build Docker image
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        build-args: |
-          SHA1VER=${{ env.SHA1VER }}
-          VERSION=${{ github.event.inputs.release_version }}
-        tags: |
-            ghcr.io/lamassuiot/lamassu-ui:${{ github.event.inputs.release_version }}
-        push: true
-      
+          
     - name: Create tag
       uses: actions/github-script@v7
       with:


### PR DESCRIPTION
This pull request makes significant changes to the pre-release workflow for building and releasing Docker images. The main update is the removal of steps related to logging into the GitHub Container Registry and building/pushing Docker images, streamlining the workflow.

Workflow simplification:

* Removed the `Login to Github Registry` step, which previously used `docker/login-action` to authenticate with the GitHub Container Registry. (.github/workflows/pre-release.yml)
* Removed the `Build Docker image` step, which previously used `docker/build-push-action` to build and push Docker images to the registry. (.github/workflows/pre-release.yml)