### PR TITLE
fix: flatten CA list when assigning identity to device

### DIFF
--- a/src/components/shared/AssignIdentityModal.tsx
+++ b/src/components/shared/AssignIdentityModal.tsx
@@ -1,4 +1,5 @@
 
+
 'use client';
 
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
@@ -32,6 +33,24 @@ interface AssignIdentityModalProps {
   deviceRaId?: string;
   isAssigning: boolean;
 }
+
+// Helper to flatten the CA hierarchy
+const flattenCaTree = (cas: CA[]): CA[] => {
+  const flatList: CA[] = [];
+  function recurse(items: CA[]) {
+    for (const item of items) {
+      // Add the parent but without its children to avoid duplication in the flat list
+      const { children, ...rest } = item;
+      flatList.push(rest as CA);
+      if (children) {
+        recurse(children);
+      }
+    }
+  }
+  recurse(cas);
+  return flatList;
+};
+
 
 export const AssignIdentityModal: React.FC<AssignIdentityModalProps> = ({
   isOpen,
@@ -124,7 +143,8 @@ export const AssignIdentityModal: React.FC<AssignIdentityModalProps> = ({
             fetchCryptoEngines(user.access_token)
         ]);
         
-        const activeCAs = cas.filter(ca => ca.status === 'active' && ca.caType !== 'EXTERNAL_PUBLIC');
+        const flatCaList = flattenCaTree(cas);
+        const activeCAs = flatCaList.filter(ca => ca.status === 'active' && ca.caType !== 'EXTERNAL_PUBLIC');
         setAllAvailableCAs(activeCAs);
         setAllCryptoEngines(engines);
     } catch (e: any) {


### PR DESCRIPTION
This pull request refactors how Certificate Authorities (CAs) are processed in the `AssignIdentityModal` component to ensure that all CAs, including those nested within a hierarchy, are considered when filtering for active, non-external CAs. The main change is the introduction of a helper function to flatten the CA tree structure.

**CA hierarchy handling:**

* Added a `flattenCaTree` helper function to traverse and flatten the hierarchical CA structure, so that all CAs (including nested ones) are included in filtering and selection logic.
* Updated the logic in `AssignIdentityModal` to use the flattened CA list when filtering for active, non-external CAs, ensuring no nested CA is missed.

**Other changes:**

* Added `'use client';` directive at the top of the file to explicitly mark the component as a client-side React component.