### PR TITLE
feat: implement RA delete action

### DIFF
--- a/src/lib/dms-api.ts
+++ b/src/lib/dms-api.ts
@@ -224,3 +224,15 @@ export async function deleteRaIntegration(raId: string, integrationKey: string, 
     // 5. Call the existing update function to save the modified RA
     await createOrUpdateRa(payload, accessToken, true, raId);
 }
+
+export async function deleteRa(raId: string, accessToken: string): Promise<void> {
+    const url = `${DMS_MANAGER_API_BASE_URL}/dms/${raId}`;
+    const response = await fetch(url, {
+        method: 'DELETE',
+        headers: { 'Authorization': `Bearer ${accessToken}` },
+    });
+
+    if (!response.ok) {
+        await handleApiError(response, 'Failed to delete Registration Authority');
+    }
+}


### PR DESCRIPTION
This pull request adds the ability to delete a Registration Authority (RA) from the registration authorities page. It introduces a new API function for deletion, integrates a confirmation dialog in the UI, and provides user feedback via toast notifications. The changes also refactor the RA deletion flow from a placeholder to a fully functional process.

**Registration Authority Deletion Feature:**

* Added a new `deleteRa` API function to `dms-api.ts` for deleting RAs using a DELETE request.
* Integrated a confirmation dialog (`AlertDialog`) in `page.tsx` to prompt users before deleting an RA, with support for loading state and cancellation.
* Updated the RA actions dropdown to trigger the delete dialog instead of a placeholder alert.

**User Feedback and State Management:**

* Implemented toast notifications to inform users about successful deletion or errors during the process. [[1]](diffhunk://#diff-678129c6058898b3c3640e185ccd2a8abd4b7e6889e64a7ee1b1cdd5a8882594R74) [[2]](diffhunk://#diff-678129c6058898b3c3640e185ccd2a8abd4b7e6889e64a7ee1b1cdd5a8882594R245-R270)
* Added state variables in `page.tsx` to manage the deletion process, including tracking the RA to delete and loading state.

**Dependency Updates:**

* Imported necessary UI components and hooks to support the new dialog and toast functionality. [[1]](diffhunk://#diff-678129c6058898b3c3640e185ccd2a8abd4b7e6889e64a7ee1b1cdd5a8882594L6-R6) [[2]](diffhunk://#diff-678129c6058898b3c3640e185ccd2a8abd4b7e6889e64a7ee1b1cdd5a8882594L42-R58)