### PR TITLE
fix: avoid constants in API domain definiton

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,57 @@
+# Dependencies
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Next.js build output
+.next/
+out/
+
+# Environment variables
+.env*
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+
+# Docker
+Dockerfile*
+docker-compose*.yml
+.dockerignore
+
+# Testing
+coverage/
+.nyc_output/
+
+# Logs
+logs/
+*.log
+
+# Runtime data
+pids/
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage/
+
+# Temporary folders
+tmp/
+temp/

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@
 import './globals.css';
 import { Toaster } from "@/components/ui/toaster";
 import { AuthProvider, useAuth } from '@/contexts/AuthContext';
+import { ConfigProvider } from '@/contexts/ConfigContext';
 import Script from 'next/script';
 
 import React, { useState, useEffect } from 'react';
@@ -25,6 +26,7 @@ import {
   SidebarTrigger,
 } from '@/components/ui/sidebar';
 import { ThemeToggle } from '@/components/shared/ThemeToggle';
+import { useConfig } from '@/contexts/ConfigContext';
 import { FileText, Users, Landmark, ShieldCheck, HomeIcon, ChevronsLeft, ChevronsRight, Router, KeyRound, ScrollTextIcon, LogIn, LogOut, Loader2, Cpu, Info, User, Blocks, Binary } from 'lucide-react';
 import { Breadcrumbs, type BreadcrumbItem } from '@/components/ui/breadcrumbs';
 import { Button } from '@/components/ui/button';
@@ -83,54 +85,54 @@ const PATH_SEGMENT_TO_LABEL_MAP: Record<string, string> = {
 };
 
 interface NavItem {
-    href: string;
-    label: string;
-    icon: React.ElementType;
-    devOnly?: boolean;
+  href: string;
+  label: string;
+  icon: React.ElementType;
+  devOnly?: boolean;
 }
 
 interface NavGroup {
-    label?: string;
-    items: NavItem[];
-    devOnly?: boolean;
+  label?: string;
+  items: NavItem[];
+  devOnly?: boolean;
 }
 
 const navigationConfig: NavGroup[] = [
-    { items: [{ href: '/', label: 'Home', icon: HomeIcon }] },
-    {
-        label: 'KMS',
-        items: [
-            { href: '/kms/keys', label: 'Keys', icon: KeyRound, devOnly: true },
-            { href: '/crypto-engines', label: 'Crypto Engines', icon: Cpu },
-        ],
-    },
-    {
-        label: 'PKI',
-        items: [
-            { href: '/certificates', label: 'Certificates', icon: FileText },
-            { href: '/certificate-authorities', label: 'Certification Authorities', icon: Landmark },
-            { href: '/signing-profiles', label: 'Issuance Profiles', icon: ScrollTextIcon },
-            { href: '/registration-authorities', label: 'Registration Authorities', icon: Users },
-            { href: '/verification-authorities', label: 'Verification Authorities', icon: ShieldCheck },
-        ],
-    },
-    {
-        label: 'IoT',
-        items: [
-            { href: '/devices', label: 'Devices', icon: Router },
-            { href: '/integrations', label: 'Platform Integrations', icon: Blocks },
-        ],
-    },
-    {
-        label: 'NOTIFICATIONS',
-        items: [{ href: '/alerts', label: 'Alerts', icon: Info }],
-    },
-    {
-        label: 'TOOLS',
-        items: [
-            { href: '/tools/certificate-viewer', label: 'Certificate Viewer', icon: Binary },
-        ],
-    },
+  { items: [{ href: '/', label: 'Home', icon: HomeIcon }] },
+  {
+    label: 'KMS',
+    items: [
+      { href: '/kms/keys', label: 'Keys', icon: KeyRound, devOnly: true },
+      { href: '/crypto-engines', label: 'Crypto Engines', icon: Cpu },
+    ],
+  },
+  {
+    label: 'PKI',
+    items: [
+      { href: '/certificates', label: 'Certificates', icon: FileText },
+      { href: '/certificate-authorities', label: 'Certification Authorities', icon: Landmark },
+      { href: '/signing-profiles', label: 'Issuance Profiles', icon: ScrollTextIcon },
+      { href: '/registration-authorities', label: 'Registration Authorities', icon: Users },
+      { href: '/verification-authorities', label: 'Verification Authorities', icon: ShieldCheck },
+    ],
+  },
+  {
+    label: 'IoT',
+    items: [
+      { href: '/devices', label: 'Devices', icon: Router },
+      { href: '/integrations', label: 'Platform Integrations', icon: Blocks },
+    ],
+  },
+  {
+    label: 'NOTIFICATIONS',
+    items: [{ href: '/alerts', label: 'Alerts', icon: Info }],
+  },
+  {
+    label: 'TOOLS',
+    items: [
+      { href: '/tools/certificate-viewer', label: 'Certificate Viewer', icon: Binary },
+    ],
+  },
 ];
 
 function generateBreadcrumbs(pathname: string, queryParams: URLSearchParams): BreadcrumbItem[] {
@@ -181,27 +183,26 @@ const LoadingState = () => (
 );
 
 const CustomFooter = () => {
-  const [showFooter, setShowFooter] = useState(false);
+  const { config } = useConfig();
   const [footerContent, setFooterContent] = useState('');
+  const [showFooter, setShowFooter] = useState(false);
 
   useEffect(() => {
-    // This runs only on the client, after hydration
-    const footerEnabled = (window as any).lamassuConfig?.LAMASSU_FOOTER_ENABLED === true;
-    
-    if (footerEnabled) {
-      setShowFooter(true);
-      fetch('/footer.html')
-        .then(response => {
-          if (response.ok) return response.text();
-          throw new Error('Could not load footer content.');
-        })
-        .then(html => setFooterContent(html))
-        .catch(error => {
-          console.error("Footer load error:", error);
-          setFooterContent('<p style="color: red; text-align: center;">Error: footer.html not found or failed to load.</p>');
-        });
+    if (config) {
+      const footerEnabled = config.LAMASSU_FOOTER_ENABLED === true;
+      setShowFooter(footerEnabled);
+
+      if (footerEnabled) {
+        fetch('/footer.html')
+          .then(response => response.text())
+          .then(html => setFooterContent(html))
+          .catch(error => {
+            console.error("Footer load error:", error);
+            setFooterContent('<p style="color: red; text-align: center;">Error: footer.html not found or failed to load.</p>');
+          });
+      }
     }
-  }, []); // Empty dependency array ensures this runs once after the initial render
+  }, [config]);
 
   if (!showFooter) {
     return null;
@@ -216,12 +217,17 @@ const CustomFooter = () => {
 };
 
 const MainLayoutContent = ({ children }: { children: React.ReactNode }) => {
+  console.log("MainLayoutContent: Rendering main layout content");
+  useEffect(() => {
+    console.log("MainLayoutContent: Mounted");
+  }, []);
+
   const { isAuthenticated, user, login, logout } = useAuth();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
   const [isStatusModalOpen, setIsStatusModalOpen] = useState(false);
-  
+
   const breadcrumbItems = generateBreadcrumbs(pathname, searchParams);
   let userRoles: string[] = [];
   if (isAuthenticated() && user?.access_token) {
@@ -243,15 +249,15 @@ const MainLayoutContent = ({ children }: { children: React.ReactNode }) => {
             {isAuthenticated() && (
               <SidebarTrigger className="md:hidden text-header-foreground hover:bg-header/80 hover:text-header-foreground" />
             )}
-             <div className="secondary-logo-container">
-               <div
-                  className="secondary-logo h-full w-auto aspect-[200/60]"
-                  data-ai-hint="logo"
-                  role="img"
-                  aria-label="Secondary Logo"
-                />
-               <Separator orientation="vertical" className="h-full bg-header-foreground/30" />
-              </div>
+            <div className="secondary-logo-container">
+              <div
+                className="secondary-logo h-full w-auto aspect-[200/60]"
+                data-ai-hint="logo"
+                role="img"
+                aria-label="Secondary Logo"
+              />
+              <Separator orientation="vertical" className="h-full bg-header-foreground/30" />
+            </div>
             <Image
               src={LogoFullWhite}
               height={60}
@@ -274,8 +280,8 @@ const MainLayoutContent = ({ children }: { children: React.ReactNode }) => {
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <Button variant="ghost" className="flex items-center gap-2 p-1 h-auto text-header-foreground hover:bg-header/80 hover:text-header-foreground">
-                    <span className='hidden sm:inline'>{user?.profile.name || user?.profile.email}</span>
-                       <div className='flex items-center justify-center bg-header-foreground/20 rounded-full h-8 w-8'>
+                      <span className='hidden sm:inline'>{user?.profile.name || user?.profile.email}</span>
+                      <div className='flex items-center justify-center bg-header-foreground/20 rounded-full h-8 w-8'>
                         <User className="h-5 w-5 text-header-foreground" />
                       </div>
                     </Button>
@@ -319,9 +325,9 @@ const MainLayoutContent = ({ children }: { children: React.ReactNode }) => {
             <Sidebar collapsible="icon" className="border-r bg-sidebar text-sidebar-foreground">
               <SidebarHeader className="p-4">
                 <div className="flex items-center gap-2 group-data-[collapsible=icon]:justify-center">
-                   <div className="secondary-logo-container group-data-[collapsible=icon]:hidden">
-                     <div className="secondary-logo h-[30px] w-auto aspect-[200/60]"/>
-                   </div>
+                  <div className="secondary-logo-container group-data-[collapsible=icon]:hidden">
+                    <div className="secondary-logo h-[30px] w-auto aspect-[200/60]" />
+                  </div>
                   <Image
                     src={LogoFullBlue}
                     height={30}
@@ -329,7 +335,7 @@ const MainLayoutContent = ({ children }: { children: React.ReactNode }) => {
                     alt="LamassuIoT Logo"
                     className="group-data-[collapsible=icon]:hidden dark:hidden"
                   />
-                   <Image
+                  <Image
                     src={LogoFullWhite}
                     height={30}
                     width={140}
@@ -348,40 +354,40 @@ const MainLayoutContent = ({ children }: { children: React.ReactNode }) => {
               <SidebarContent className="p-2">
                 <SidebarMenu>
                   {navigationConfig.map((group, groupIndex) => {
-                    if (group.devOnly && !(process.env.NODE_ENV == 'development' ||  process.env.NEXT_FORCE_DEV_OPTIONS)) {
-                        return null;
+                    if (group.devOnly && !(process.env.NODE_ENV == 'development' || process.env.NEXT_FORCE_DEV_OPTIONS)) {
+                      return null;
                     }
-                    
-                    const filteredItems = group.items.filter(item => 
-                        !(item.devOnly && !(process.env.NODE_ENV == 'development' ||  process.env.NEXT_FORCE_DEV_OPTIONS))
+
+                    const filteredItems = group.items.filter(item =>
+                      !(item.devOnly && !(process.env.NODE_ENV == 'development' || process.env.NEXT_FORCE_DEV_OPTIONS))
                     );
 
                     if (filteredItems.length === 0) {
-                        return null;
+                      return null;
                     }
 
                     return (
-                        <React.Fragment key={group.label || `group-${groupIndex}`}>
-                            {group.label && (
-                                <SidebarGroupLabel className="px-2 pt-2 group-data-[collapsible=icon]:pt-0">
-                                    {group.label}
-                                </SidebarGroupLabel>
-                            )}
-                            {filteredItems.map(item => (
-                                <SidebarMenuItem key={item.href}>
-                                    <SidebarMenuButton
-                                        asChild
-                                        isActive={pathname.startsWith(item.href) && (item.href !== '/' || pathname === '/')}
-                                        tooltip={{ children: item.label, side: 'right', align: 'center' }}
-                                    >
-                                        <Link href={item.href} className="flex items-center w-full justify-start">
-                                            <item.icon className="mr-2 h-5 w-5 flex-shrink-0" />
-                                            <span className="group-data-[collapsible=icon]:hidden whitespace-nowrap">{item.label}</span>
-                                        </Link>
-                                    </SidebarMenuButton>
-                                </SidebarMenuItem>
-                            ))}
-                        </React.Fragment>
+                      <React.Fragment key={group.label || `group-${groupIndex}`}>
+                        {group.label && (
+                          <SidebarGroupLabel className="px-2 pt-2 group-data-[collapsible=icon]:pt-0">
+                            {group.label}
+                          </SidebarGroupLabel>
+                        )}
+                        {filteredItems.map(item => (
+                          <SidebarMenuItem key={item.href}>
+                            <SidebarMenuButton
+                              asChild
+                              isActive={pathname.startsWith(item.href) && (item.href !== '/' || pathname === '/')}
+                              tooltip={{ children: item.label, side: 'right', align: 'center' }}
+                            >
+                              <Link href={item.href} className="flex items-center w-full justify-start">
+                                <item.icon className="mr-2 h-5 w-5 flex-shrink-0" />
+                                <span className="group-data-[collapsible=icon]:hidden whitespace-nowrap">{item.label}</span>
+                              </Link>
+                            </SidebarMenuButton>
+                          </SidebarMenuItem>
+                        ))}
+                      </React.Fragment>
                     );
                   })}
                 </SidebarMenu>
@@ -389,12 +395,12 @@ const MainLayoutContent = ({ children }: { children: React.ReactNode }) => {
               <SidebarFooter className="p-2 pb-4 mt-auto border-t border-sidebar-border">
                 <CustomSidebarToggle />
                 <div className="w-full group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center">
-                    
+
                 </div>
               </SidebarFooter>
             </Sidebar>
 
-            <SidebarInset className="flex-1 overflow-y-auto p-4 md:p-6">
+            <SidebarInset className="flex-1 overflow-y-auto p-4 md:p-6 pb-8 md:pb-12">
               {breadcrumbItems.length > 1 && <Breadcrumbs items={breadcrumbItems} />}
               {children}
               <CustomFooter />
@@ -442,9 +448,9 @@ const MainLayoutContent = ({ children }: { children: React.ReactNode }) => {
             <div>
               <h4 className="text-sm font-semibold text-muted-foreground mb-2">ID Token Claims</h4>
               <ScrollArea className="h-60 w-full rounded-md border p-4 bg-muted/30">
-                  <pre className="text-xs whitespace-pre-wrap break-all">
+                <pre className="text-xs whitespace-pre-wrap break-all">
                   {user ? JSON.stringify(user.profile, null, 2) : "No user profile data available."}
-                  </pre>
+                </pre>
               </ScrollArea>
             </div>
           </div>
@@ -462,6 +468,11 @@ const MainLayoutContent = ({ children }: { children: React.ReactNode }) => {
 
 
 const InnerLayout = ({ children }: { children: React.ReactNode }) => {
+  console.log("InnerLayout: Rendering layout component");
+  useEffect(() => {
+    console.log("InnerLayout: Mounted");
+  }, []);
+
   const { isLoading: authIsLoading } = useAuth();
   const [clientMounted, setClientMounted] = React.useState(false);
   const pathname = usePathname();
@@ -482,9 +493,9 @@ const InnerLayout = ({ children }: { children: React.ReactNode }) => {
   if (!clientMounted) {
     return <LoadingState />;
   }
-  
+
   if (authIsLoading) {
-      return <LoadingState />;
+    return <LoadingState />;
   }
 
   return <MainLayoutContent>{children}</MainLayoutContent>;
@@ -508,12 +519,14 @@ export default function RootLayout({
         <link rel="stylesheet" href="/custom-theme.css"></link>
       </head>
       <body className="font-body antialiased">
-        <AuthProvider>
-          <React.Suspense fallback={<LoadingState />}>
-            <InnerLayout>{children}</InnerLayout>
-          </React.Suspense>
-          <Toaster />
-        </AuthProvider>
+        <ConfigProvider>
+          <AuthProvider>
+            <React.Suspense fallback={<LoadingState />}>
+              <InnerLayout>{children}</InnerLayout>
+            </React.Suspense>
+            <Toaster />
+          </AuthProvider>
+        </ConfigProvider>
       </body>
     </html>
   );
@@ -521,7 +534,7 @@ export default function RootLayout({
 
 function CustomSidebarToggle() {
   const { open, toggleSidebar, isMobile } = useSidebar();
-  
+
   if (isMobile) {
     return null;
   }

--- a/src/app/registration-authorities/cacerts/page.tsx
+++ b/src/app/registration-authorities/cacerts/page.tsx
@@ -12,7 +12,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { DetailItem } from '@/components/shared/DetailItem';
 import { Badge } from '@/components/ui/badge';
 import { CodeBlock } from '@/components/shared/CodeBlock';
-import { EST_API_BASE_URL } from '@/lib/api-domains';
+import { get_EST_API_BASE_URL } from '@/lib/api-domains';
 import { fetchEstCaCerts } from '@/lib/est-api';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
@@ -128,8 +128,8 @@ export default function EstCaCertsPage() {
         fetchData();
     }, [fetchData]);
 
-    const curlPkcs7 = `curl ${EST_API_BASE_URL}/${raId}/cacerts \\ \n  -H "Accept: application/pkcs7-mime"`;
-    const curlPem = `curl ${EST_API_BASE_URL}/${raId}/cacerts \\ \n  -H "Accept: application/x-pem-file"`;
+    const curlPkcs7 = `curl ${get_EST_API_BASE_URL()}/${raId}/cacerts \\ \n  -H "Accept: application/pkcs7-mime"`;
+    const curlPem = `curl ${get_EST_API_BASE_URL()}/${raId}/cacerts \\ \n  -H "Accept: application/x-pem-file"`;
 
     if (isLoading || authLoading) {
         return (

--- a/src/components/devices/RegisterDeviceModal.tsx
+++ b/src/components/devices/RegisterDeviceModal.tsx
@@ -14,7 +14,7 @@ import { useToast } from '@/hooks/use-toast';
 import { TagInput } from '@/components/shared/TagInput';
 import { DeviceIconSelectorModal, getLucideIconByName } from '@/components/shared/DeviceIconSelectorModal';
 import { Separator } from '../ui/separator';
-import { DMS_MANAGER_API_BASE_URL } from '@/lib/api-domains';
+import { get_DMS_MANAGER_API_BASE_URL } from '@/lib/api-domains';
 import { registerDevice } from '@/lib/devices-api';
 
 // Re-defining RA types here to avoid complex imports, but ideally these would be shared
@@ -98,7 +98,7 @@ export const RegisterDeviceModal: React.FC<RegisterDeviceModalProps> = ({
     setIsLoadingRas(true);
     setErrorRas(null);
     try {
-      const response = await fetch(`${DMS_MANAGER_API_BASE_URL}/dms?page_size=100`, {
+      const response = await fetch(`${get_DMS_MANAGER_API_BASE_URL()}/dms?page_size=100`, {
         headers: { 'Authorization': `Bearer ${user.access_token}` },
       });
       if (!response.ok) {

--- a/src/components/shared/BackendStatusDialog.tsx
+++ b/src/components/shared/BackendStatusDialog.tsx
@@ -8,11 +8,11 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Loader2, CheckCircle, XCircle, RefreshCw } from "lucide-react";
 import { useAuth } from '@/contexts/AuthContext';
 import {
-  CA_API_BASE_URL,
-  DEV_MANAGER_API_BASE_URL,
-  DMS_MANAGER_API_BASE_URL,
-  ALERTS_API_BASE_URL,
-  VA_API_BASE_URL
+  get_CA_API_BASE_URL,
+  get_DEV_MANAGER_API_BASE_URL,
+  get_DMS_MANAGER_API_BASE_URL,
+  get_ALERTS_API_BASE_URL,
+  get_VA_API_BASE_URL
 } from '@/lib/api-domains';
 import { cn } from '@/lib/utils';
 import { Badge } from '../ui/badge';
@@ -34,11 +34,11 @@ interface ServiceStatus {
 }
 
 const servicesToCheck = [
-    { name: 'CA Service', url: CA_API_BASE_URL },
-    { name: 'Device Manager', url: DEV_MANAGER_API_BASE_URL },
-    { name: 'DMS Manager', url: DMS_MANAGER_API_BASE_URL },
-    { name: 'Alerts Service', url: ALERTS_API_BASE_URL },
-    { name: 'Validation Authority', url: VA_API_BASE_URL }
+    { name: 'CA Service', url: get_CA_API_BASE_URL() },
+    { name: 'Device Manager', url: get_DEV_MANAGER_API_BASE_URL() },
+    { name: 'DMS Manager', url: get_DMS_MANAGER_API_BASE_URL() },
+    { name: 'Alerts Service', url: get_ALERTS_API_BASE_URL() },
+    { name: 'Validation Authority', url: get_VA_API_BASE_URL() }
 ];
 
 export const BackendStatusDialog: React.FC<BackendStatusDialogProps> = ({ isOpen, onOpenChange }) => {

--- a/src/components/shared/EstEnrollModal.tsx
+++ b/src/components/shared/EstEnrollModal.tsx
@@ -16,7 +16,7 @@ import { DurationInput } from './DurationInput';
 import type { ApiCryptoEngine } from '@/types/crypto-engine';
 import { Alert, AlertDescription as AlertDescUI, AlertTitle } from '../ui/alert';
 import { CodeBlock } from './CodeBlock';
-import { EST_API_BASE_URL } from '@/lib/api-domains';
+import { get_EST_API_BASE_URL } from '@/lib/api-domains';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { KEY_TYPE_OPTIONS, RSA_KEY_SIZE_OPTIONS, ECDSA_CURVE_OPTIONS } from '@/lib/key-spec-constants';
 import { useAuth } from '@/contexts/AuthContext';
@@ -321,7 +321,7 @@ export const EstEnrollModal: React.FC<EstEnrollModalProps> = ({ isOpen, onOpenCh
     
     const finalEnrollCommand = [
       `echo "Performing enrollment..."`,
-      `curl -v --cert bootstrap.cert --key bootstrap.key ${curlValidationFlag} -H "Content-Type: application/pkcs10" --data-binary @${finalDeviceId}.stripped.csr   -o ${finalDeviceId}.p7 "${EST_API_BASE_URL}/${ra?.id}/simpleenroll"`,
+      `curl -v --cert bootstrap.cert --key bootstrap.key ${curlValidationFlag} -H "Content-Type: application/pkcs10" --data-binary @${finalDeviceId}.stripped.csr   -o ${finalDeviceId}.p7 "${get_EST_API_BASE_URL()}/${ra?.id}/simpleenroll"`,
       `echo "Extracting new certificate..."`,
       `openssl base64 -d -in ${finalDeviceId}.p7 | openssl pkcs7 -inform DER -outform PEM -print_certs -out ${finalDeviceId}.crt`,
       `echo "Verifying new certificate..."`,
@@ -333,7 +333,7 @@ export const EstEnrollModal: React.FC<EstEnrollModalProps> = ({ isOpen, onOpenCh
     const dummyStripCommand = `cat dummy.csr | sed '/-----BEGIN CERTIFICATE REQUEST-----/d'  | sed '/-----END CERTIFICATE REQUEST-----/d'> dummy.stripped.csr`;
     const dummyCombinedCommand = `${dummyKeygenCommand}\n\n# Strip header/footer from CSR for cURL\n${dummyStripCommand}`;
     
-    const serverKeygenCurlCommand = `curl -v --cert bootstrap.cert --key bootstrap.key ${curlValidationFlag} -H "Content-Type: application/pkcs10" --data-binary @dummy.stripped.csr -o ${finalDeviceId}.multipart "${EST_API_BASE_URL}/${ra?.id}/serverkeygen"`;
+    const serverKeygenCurlCommand = `curl -v --cert bootstrap.cert --key bootstrap.key ${curlValidationFlag} -H "Content-Type: application/pkcs10" --data-binary @dummy.stripped.csr -o ${finalDeviceId}.multipart "${get_EST_API_BASE_URL()}/${ra?.id}/serverkeygen"`;
     
     const serverKeygenParseCommands = [
         `# 3. Extract Private Key`,

--- a/src/components/shared/EstReEnrollModal.tsx
+++ b/src/components/shared/EstReEnrollModal.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/lib/utils";
 import { useToast } from '@/hooks/use-toast';
 import { Alert, AlertDescription as AlertDescUI, AlertTitle } from '../ui/alert';
 import { CodeBlock } from './CodeBlock';
-import { EST_API_BASE_URL } from '@/lib/api-domains';
+import { get_EST_API_BASE_URL } from '@/lib/api-domains';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { KEY_TYPE_OPTIONS, RSA_KEY_SIZE_OPTIONS, ECDSA_CURVE_OPTIONS } from '@/lib/key-spec-constants';
 import { Switch } from '@/components/ui/switch';
@@ -162,7 +162,7 @@ export const EstReEnrollModal: React.FC<EstReEnrollModalProps> = ({ isOpen, onOp
     
     const curlValidationFlag = validateServerCert ? '--cacert root-ca.pem' : '-k';
     const finalReEnrollCommand = [
-      `echo "Performing re-enrollment..."\ncurl -v --cert ${finalDeviceId}.existing.crt --key ${finalDeviceId}.existing.key ${curlValidationFlag} -H "Content-Type: application/pkcs10" --data-binary @${finalDeviceId}.new.stripped.csr -o ${finalDeviceId}.new.p7 "${EST_API_BASE_URL}/${ra?.id}/simplereenroll"`,
+      `echo "Performing re-enrollment..."\ncurl -v --cert ${finalDeviceId}.existing.crt --key ${finalDeviceId}.existing.key ${curlValidationFlag} -H "Content-Type: application/pkcs10" --data-binary @${finalDeviceId}.new.stripped.csr -o ${finalDeviceId}.new.p7 "${get_EST_API_BASE_URL()}/${ra?.id}/simplereenroll"`,
       `echo "Extracting new certificate..."\nopenssl base64 -d -in ${finalDeviceId}.new.p7 | openssl pkcs7 -inform DER -outform PEM -print_certs -out ${finalDeviceId}.new.crt`,
       `echo "Verifying new certificate..."\nopenssl x509 -text -noout -in ${finalDeviceId}.new.crt`
     ].join('\n\n');

--- a/src/contexts/ConfigContext.tsx
+++ b/src/contexts/ConfigContext.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { Loader2 } from 'lucide-react';
+
+interface LamassuConfig {
+  LAMASSU_AUTH_ENABLED?: boolean;
+  LAMASSU_AUTH_AUTHORITY?: string;
+  LAMASSU_AUTH_CLIENT_ID?: string;
+  LAMASSU_API?: string;
+  LAMASSU_PUBLIC_API?: string;
+  LAMASSU_CONNECTORS?: string[];
+  LAMASSU_FOOTER_ENABLED?: boolean;
+  [key: string]: any;
+}
+
+interface ConfigContextType {
+  config: LamassuConfig | null;
+  isConfigLoaded: boolean;
+  isLoading: boolean;
+}
+
+const ConfigContext = createContext<ConfigContextType | undefined>(undefined);
+
+const ConfigLoadingScreen = () => (
+  <div className="flex flex-col items-center justify-center min-h-screen bg-background text-foreground">
+    <div className="flex flex-col items-center space-y-4 text-center">
+      <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      <h2 className="text-xl font-semibold">Loading Configuration</h2>
+      <p className="text-muted-foreground max-w-md">
+        Please wait while we load the application configuration. This may take a few moments.
+      </p>
+    </div>
+  </div>
+);
+
+export const ConfigProvider = ({ children }: { children: ReactNode }) => {
+  const [config, setConfig] = useState<LamassuConfig | null>(null);
+  const [isConfigLoaded, setIsConfigLoaded] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let pollInterval: NodeJS.Timeout | null = null;
+    let attemptCount = 0;
+    const maxAttempts = 30; // Maximum 30 seconds of polling
+
+    const checkConfig = () => {
+      attemptCount++;
+
+      if (typeof window !== 'undefined') {
+        const lamassuConfig = (window as any).lamassuConfig;
+
+        console.log('Checking for lamassuConfig on window:', lamassuConfig);
+
+        if (lamassuConfig && typeof lamassuConfig === 'object') {
+          console.log('LamassuConfig found');
+          // Config is available
+          setConfig(lamassuConfig);
+          setIsConfigLoaded(true);
+          setIsLoading(false);
+
+          if (pollInterval) {
+            clearInterval(pollInterval);
+            pollInterval = null;
+          }
+
+          console.log('LamassuConfig loaded successfully:', lamassuConfig);
+          return;
+        } else {
+          console.log('LamassuConfig not found yet.');
+        }
+      }
+
+      // If we've reached max attempts, stop polling
+      if (attemptCount >= maxAttempts) {
+        console.error('LamassuConfig not found after maximum polling attempts.');
+
+        setConfig(null);
+        setIsConfigLoaded(false);
+        setIsLoading(false);
+
+        if (pollInterval) {
+          clearInterval(pollInterval);
+          pollInterval = null;
+        }
+        return;
+      }
+
+      console.log(`Polling for LamassuConfig... attempt ${attemptCount}/${maxAttempts}`);
+
+      // For debugging: log what we find
+      if (typeof window !== 'undefined') {
+        console.log('window.lamassuConfig status:', {
+          exists: !!(window as any).lamassuConfig,
+          type: typeof (window as any).lamassuConfig,
+          keys: (window as any).lamassuConfig ? Object.keys((window as any).lamassuConfig) : []
+        });
+      }
+    };
+
+    // Initial check
+    checkConfig();
+
+    // If config wasn't found immediately, start polling
+    if (!isConfigLoaded) {
+      pollInterval = setInterval(checkConfig, 1000); // Check every second
+    }
+
+    // Cleanup function
+    return () => {
+      if (pollInterval) {
+        clearInterval(pollInterval);
+      }
+    };
+  }, [isConfigLoaded]);
+
+  const contextValue: ConfigContextType = {
+    config,
+    isConfigLoaded,
+    isLoading,
+  };
+
+  // Show loading screen while waiting for config
+  if (isLoading) {
+    return (
+      <ConfigContext.Provider value={contextValue}>
+        <ConfigLoadingScreen />
+      </ConfigContext.Provider>
+    );
+  }
+
+  return (
+    <ConfigContext.Provider value={contextValue}>
+      {children}
+    </ConfigContext.Provider>
+  );
+};
+
+export const useConfig = () => {
+  const context = useContext(ConfigContext);
+  if (context === undefined) {
+    throw new Error('useConfig must be used within a ConfigProvider');
+  }
+  return context;
+};
+
+// Helper function to get config value with fallback
+export const getConfigValue = (key: string, fallback?: any) => {
+  if (typeof window !== 'undefined') {
+    const config = (window as any).lamassuConfig;
+    return config?.[key] ?? fallback;
+  }
+  return fallback;
+};

--- a/src/lib/alerts-api.ts
+++ b/src/lib/alerts-api.ts
@@ -2,7 +2,7 @@
 
 'use client'; // This can be a client-side library function
 
-import { ALERTS_API_BASE_URL } from './api-domains';
+import { get_ALERTS_API_BASE_URL } from './api-domains';
 
 export interface ApiAlertEventData {
     specversion: string;
@@ -62,7 +62,7 @@ export interface SubscriptionPayload {
 
 
 export async function fetchLatestAlerts(accessToken: string): Promise<ApiAlertEvent[]> {
-  const response = await fetch(`${ALERTS_API_BASE_URL}/events/latest`, {
+  const response = await fetch(`${get_ALERTS_API_BASE_URL()}/events/latest`, {
     headers: {
       'Authorization': `Bearer ${accessToken}`,
     },
@@ -87,7 +87,7 @@ export async function fetchLatestAlerts(accessToken: string): Promise<ApiAlertEv
 }
 
 export async function fetchSystemSubscriptions(accessToken: string): Promise<ApiSubscription[]> {
-  const response = await fetch(`${ALERTS_API_BASE_URL}/user/_lms_system/subscriptions`, {
+  const response = await fetch(`${get_ALERTS_API_BASE_URL()}/user/_lms_system/subscriptions`, {
     headers: {
       'Authorization': `Bearer ${accessToken}`,
     },
@@ -112,7 +112,7 @@ export async function fetchSystemSubscriptions(accessToken: string): Promise<Api
 }
 
 export async function subscribeToAlert(payload: SubscriptionPayload, accessToken: string): Promise<void> {
-  const response = await fetch(`${ALERTS_API_BASE_URL}/user/_lms_system/subscribe`, {
+  const response = await fetch(`${get_ALERTS_API_BASE_URL()}/user/_lms_system/subscribe`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -133,7 +133,7 @@ export async function subscribeToAlert(payload: SubscriptionPayload, accessToken
 }
 
 export async function updateSubscription(subscriptionId: string, payload: SubscriptionPayload, accessToken: string): Promise<void> {
-  const response = await fetch(`${ALERTS_API_BASE_URL}/user/_lms_system/subscriptions/${subscriptionId}`, {
+  const response = await fetch(`${get_ALERTS_API_BASE_URL()}/user/_lms_system/subscriptions/${subscriptionId}`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
@@ -154,7 +154,7 @@ export async function updateSubscription(subscriptionId: string, payload: Subscr
 }
 
 export async function unsubscribeFromAlert(subscriptionId: string, accessToken: string): Promise<void> {
-  const response = await fetch(`${ALERTS_API_BASE_URL}/user/_lms_system/unsubscribe/${subscriptionId}`, {
+  const response = await fetch(`${get_ALERTS_API_BASE_URL()}/user/_lms_system/unsubscribe/${subscriptionId}`, {
     method: 'POST',
     headers: {
       'Authorization': `Bearer ${accessToken}`,

--- a/src/lib/api-domains.ts
+++ b/src/lib/api-domains.ts
@@ -3,13 +3,16 @@
 const getApiBaseUrl = (): string => {
     // 1. Check for configuration from config.js on the window object
     if (typeof window !== 'undefined' && (window as any).lamassuConfig?.LAMASSU_API) {
+        console.log('Using LAMASSU_API from window.lamassuConfig');
         return (window as any).lamassuConfig.LAMASSU_API;
     }
     // 2. Fallback to the Next.js public environment variable
     if (process.env.NEXT_PUBLIC_API_BASE_URL) {
+        console.log('Using NEXT_PUBLIC_API_BASE_URL from environment variables');
         return process.env.NEXT_PUBLIC_API_BASE_URL;
     }
     // 3. Return an empty string if no configuration is found
+    console.warn('No API base URL configured. Please set LAMASSU_API in config.js or NEXT_PUBLIC_API_BASE_URL in environment variables.');
     return '';
 };
 
@@ -22,18 +25,15 @@ const getVaEstApiBaseUrl = (): string => {
     return getApiBaseUrl();
 }
 
-const API_BASE_URL = getApiBaseUrl();
-const VA_EST_API_BASE_URL = getVaEstApiBaseUrl();
-
-export const CA_API_BASE_URL = `${API_BASE_URL}/ca/v1`;
-export const DEV_MANAGER_API_BASE_URL = `${API_BASE_URL}/devmanager/v1`;
-export const DMS_MANAGER_API_BASE_URL = `${API_BASE_URL}/dmsmanager/v1`;
-export const ALERTS_API_BASE_URL = `${API_BASE_URL}/alerts/v1`;
+export const get_CA_API_BASE_URL = () => `${getApiBaseUrl()}/ca/v1`;
+export const get_DEV_MANAGER_API_BASE_URL = () => `${getApiBaseUrl()}/devmanager/v1`;
+export const get_DMS_MANAGER_API_BASE_URL = () => `${getApiBaseUrl()}/dmsmanager/v1`;
+export const get_ALERTS_API_BASE_URL = () => `${getApiBaseUrl()}/alerts/v1`;
 
 // These endpoints now use the potentially overridden base URL
-export const EST_API_BASE_URL = `${VA_EST_API_BASE_URL}/dmsmanager/.well-known/est`;
-export const VA_CORE_API_BASE_URL = `${VA_EST_API_BASE_URL}/va`;
-export const VA_API_BASE_URL = `${VA_CORE_API_BASE_URL}/v1`;
+export const get_EST_API_BASE_URL = () => `${getVaEstApiBaseUrl()}/dmsmanager/.well-known/est`;
+export const get_VA_CORE_API_BASE_URL = () => `${getVaEstApiBaseUrl()}/va`;
+export const get_VA_API_BASE_URL = () => `${get_VA_CORE_API_BASE_URL()}/v1`;
 
 export const handleApiError = async (response: Response, defaultMessage: string) => {
     if (!response.ok) {

--- a/src/lib/ca-data.ts
+++ b/src/lib/ca-data.ts
@@ -4,7 +4,7 @@
 import * as asn1js from "asn1js";
 import { Certificate, CRLDistributionPoints, BasicConstraints, ExtKeyUsage, RelativeDistinguishedNames, PublicKeyInfo, AuthorityKeyIdentifier } from "pkijs";
 import type { ApiCryptoEngine } from '@/types/crypto-engine';
-import { CA_API_BASE_URL, DEV_MANAGER_API_BASE_URL, handleApiError } from "./api-domains";
+import { get_CA_API_BASE_URL, get_DEV_MANAGER_API_BASE_URL, handleApiError } from "./api-domains";
 
 // API Response Structures
 interface ApiKeyMetadata {
@@ -458,7 +458,7 @@ export async function fetchAndProcessCAs(accessToken: string, apiQueryString?: s
     let hasNextPage = true;
     
     // Base URL setup
-    const baseUrl = `${CA_API_BASE_URL}/cas`;
+    const baseUrl = `${get_CA_API_BASE_URL()}/cas`;
     const initialParams = new URLSearchParams(apiQueryString);
     initialParams.set('page_size', '25');
 
@@ -539,7 +539,7 @@ export function findCaByCommonName(commonName: string | undefined | null, cas: C
 }
 
 export async function fetchCryptoEngines(accessToken: string): Promise<ApiCryptoEngine[]> {
-    const response = await fetch(`${CA_API_BASE_URL}/engines`, {
+    const response = await fetch(`${get_CA_API_BASE_URL()}/engines`, {
         headers: { 'Authorization': `Bearer ${accessToken}` },
     });
     if (!response.ok) {
@@ -584,7 +584,7 @@ export interface CreateCaPayload {
 }
 
 export async function createCa(payload: CreateCaPayload, accessToken: string): Promise<void> {
-  const response = await fetch(`${CA_API_BASE_URL}/cas`, {
+  const response = await fetch(`${get_CA_API_BASE_URL()}/cas`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -627,7 +627,7 @@ export interface CreateCaRequestPayload {
 }
 
 export async function createCaRequest(payload: CreateCaRequestPayload, accessToken: string): Promise<void> {
-  const response = await fetch(`${CA_API_BASE_URL}/cas/requests`, {
+  const response = await fetch(`${get_CA_API_BASE_URL()}/cas/requests`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -663,7 +663,7 @@ export interface CACertificateRequest {
 }
 
 export async function fetchCaRequests(params: URLSearchParams, accessToken: string): Promise<{ list: CACertificateRequest[]; next: string | null }> {
-    const url = `${CA_API_BASE_URL}/cas/requests?${params.toString()}`;
+    const url = `${get_CA_API_BASE_URL()}/cas/requests?${params.toString()}`;
     const response = await fetch(url, {
         headers: { 'Authorization': `Bearer ${accessToken}` },
     });
@@ -680,7 +680,7 @@ export async function fetchCaRequests(params: URLSearchParams, accessToken: stri
 }
 
 export async function deleteCaRequest(requestId: string, accessToken: string): Promise<void> {
-    const response = await fetch(`${CA_API_BASE_URL}/cas/requests/${requestId}`, {
+    const response = await fetch(`${get_CA_API_BASE_URL()}/cas/requests/${requestId}`, {
         method: 'DELETE',
         headers: { 'Authorization': `Bearer ${accessToken}` },
     });
@@ -711,7 +711,7 @@ export interface ImportCaPayload {
 }
 
 export async function importCa(payload: ImportCaPayload, accessToken: string): Promise<void> {
-  const response = await fetch(`${CA_API_BASE_URL}/cas/import`, {
+  const response = await fetch(`${get_CA_API_BASE_URL()}/cas/import`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -740,7 +740,7 @@ export interface PatchOperation {
 }
 
 export async function updateCaMetadata(caId: string, patchOperations: PatchOperation[], accessToken: string): Promise<void> {
-  const response = await fetch(`${CA_API_BASE_URL}/cas/${caId}/metadata`, {
+  const response = await fetch(`${get_CA_API_BASE_URL()}/cas/${caId}/metadata`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
@@ -765,7 +765,7 @@ interface CaStats {
   REVOKED: number;
 }
 export async function fetchCaStats(caId: string, accessToken: string): Promise<CaStats> {
-    const response = await fetch(`${CA_API_BASE_URL}/stats/${caId}`, {
+    const response = await fetch(`${get_CA_API_BASE_URL()}/stats/${caId}`, {
         headers: { 'Authorization': `Bearer ${accessToken}` },
     });
     if (!response.ok) {
@@ -784,7 +784,7 @@ export async function updateCaStatus(caId: string, status: 'ACTIVE' | 'REVOKED',
     if (status === 'REVOKED' && reason) {
         body.revocation_reason = reason;
     }
-    const response = await fetch(`${CA_API_BASE_URL}/cas/${caId}/status`, {
+    const response = await fetch(`${get_CA_API_BASE_URL()}/cas/${caId}/status`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -804,7 +804,7 @@ export async function updateCaStatus(caId: string, status: 'ACTIVE' | 'REVOKED',
 }
 
 export async function revokeCa(caId: string, reason: string, accessToken: string): Promise<void> {
-  const response = await fetch(`${CA_API_BASE_URL}/cas/${caId}/status`, {
+  const response = await fetch(`${get_CA_API_BASE_URL()}/cas/${caId}/status`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -826,7 +826,7 @@ export async function revokeCa(caId: string, reason: string, accessToken: string
 
 
 export async function deleteCa(caId: string, accessToken: string): Promise<void> {
-    const response = await fetch(`${CA_API_BASE_URL}/cas/${caId}`, {
+    const response = await fetch(`${get_CA_API_BASE_URL()}/cas/${caId}`, {
         method: 'DELETE',
         headers: { 'Authorization': `Bearer ${accessToken}` },
     });
@@ -843,7 +843,7 @@ export async function deleteCa(caId: string, accessToken: string): Promise<void>
 }
 
 export async function signCertificate(caId: string, payload: any, accessToken: string): Promise<any> {
-    const response = await fetch(`${CA_API_BASE_URL}/cas/${caId}/certificates/sign`, {
+    const response = await fetch(`${get_CA_API_BASE_URL()}/cas/${caId}/certificates/sign`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${accessToken}` },
         body: JSON.stringify(payload)
@@ -856,7 +856,7 @@ export async function signCertificate(caId: string, payload: any, accessToken: s
 }
 
 export async function fetchCaRequestById(requestId: string, accessToken: string): Promise<any> {
-    const response = await fetch(`${CA_API_BASE_URL}/cas/requests?filter=id[equal]${requestId}`, {
+    const response = await fetch(`${get_CA_API_BASE_URL()}/cas/requests?filter=id[equal]${requestId}`, {
         headers: { 'Authorization': `Bearer ${accessToken}` },
     });
     if (!response.ok) throw new Error("Failed to fetch CA request details.");
@@ -885,7 +885,7 @@ export interface ApiKmsKeyListResponse {
 
 
 export async function fetchKmsKeys(accessToken: string, apiQueryString?: string): Promise<ApiKmsKeyListResponse> {
-    const url = `${CA_API_BASE_URL}/kms/keys?${apiQueryString || ''}`;
+    const url = `${get_CA_API_BASE_URL()}/kms/keys?${apiQueryString || ''}`;
     const response = await fetch(url, {
         headers: { 'Authorization': `Bearer ${accessToken}` },
     });
@@ -902,7 +902,7 @@ export async function fetchKmsKeys(accessToken: string, apiQueryString?: string)
 }
 
 export async function signWithKmsKey(keyId: string, payload: any, accessToken: string): Promise<any> {
-    const response = await fetch(`${CA_API_BASE_URL}/kms/keys/${encodeURIComponent(keyId)}/sign`, {
+    const response = await fetch(`${get_CA_API_BASE_URL()}/kms/keys/${encodeURIComponent(keyId)}/sign`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -918,7 +918,7 @@ export async function signWithKmsKey(keyId: string, payload: any, accessToken: s
 }
 
 export async function verifyWithKmsKey(keyId: string, payload: any, accessToken: string): Promise<{ valid: boolean }> {
-    const response = await fetch(`${CA_API_BASE_URL}/kms/keys/${encodeURIComponent(keyId)}/verify`, {
+    const response = await fetch(`${get_CA_API_BASE_URL()}/kms/keys/${encodeURIComponent(keyId)}/verify`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -942,7 +942,7 @@ export async function verifyWithKmsKey(keyId: string, payload: any, accessToken:
 
 
 export async function createKmsKey(payload: { engine_id: string; algorithm: string; size: number; name: string }, accessToken: string): Promise<void> {
-    const response = await fetch(`${CA_API_BASE_URL}/kms/keys`, {
+    const response = await fetch(`${get_CA_API_BASE_URL()}/kms/keys`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -962,7 +962,7 @@ export async function createKmsKey(payload: { engine_id: string; algorithm: stri
 }
 
 export async function updateCaDefaultProfileId(caId: string, profileId: string | null, accessToken: string): Promise<void> {
-    const response = await fetch(`${CA_API_BASE_URL}/cas/${caId}/issuance-profile`, {
+    const response = await fetch(`${get_CA_API_BASE_URL()}/cas/${caId}/issuance-profile`, {
         method: 'PUT',
         headers: {
             'Content-Type': 'application/json',
@@ -988,14 +988,14 @@ export interface CaStatsSummaryResponse {
 }
 
 export async function fetchCaStatsSummary(accessToken: string): Promise<CaStatsSummaryResponse> {
-    const response = await fetch(`${CA_API_BASE_URL}/stats`, {
+    const response = await fetch(`${get_CA_API_BASE_URL()}/stats`, {
         headers: { 'Authorization': `Bearer ${accessToken}` },
     });
     return handleApiError(response, 'Failed to fetch CA stats');
 }
 
 export async function fetchDevManagerStats(accessToken: string): Promise<{ total: number }> {
-    const response = await fetch(`${DEV_MANAGER_API_BASE_URL}/stats`, { 
+    const response = await fetch(`${get_DEV_MANAGER_API_BASE_URL()}/stats`, { 
         headers: { 'Authorization': `Bearer ${accessToken}` } 
     });
     return handleApiError(response, 'Failed to fetch Device stats');
@@ -1041,7 +1041,7 @@ export interface ApiSigningProfileListResponse {
 }
 
 export async function fetchSigningProfiles(accessToken: string, params?: URLSearchParams): Promise<ApiSigningProfileListResponse> {
-    const url = new URL(`${CA_API_BASE_URL}/profiles`);
+    const url = new URL(`${get_CA_API_BASE_URL()}/profiles`);
     if (params) {
         params.forEach((value, key) => url.searchParams.append(key, value));
     }
@@ -1093,7 +1093,7 @@ export interface CreateSigningProfilePayload {
 }
 
 export async function createSigningProfile(payload: CreateSigningProfilePayload, accessToken: string): Promise<ApiSigningProfile> {
-    const response = await fetch(`${CA_API_BASE_URL}/profiles`, {
+    const response = await fetch(`${get_CA_API_BASE_URL()}/profiles`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -1114,7 +1114,7 @@ export async function createSigningProfile(payload: CreateSigningProfilePayload,
 }
 
 export async function fetchSigningProfileById(profileId: string, accessToken: string): Promise<ApiSigningProfile> {
-    const response = await fetch(`${CA_API_BASE_URL}/profiles/${profileId}`, {
+    const response = await fetch(`${get_CA_API_BASE_URL()}/profiles/${profileId}`, {
         headers: { 'Authorization': `Bearer ${accessToken}` },
     });
     if (!response.ok) {
@@ -1130,7 +1130,7 @@ export async function fetchSigningProfileById(profileId: string, accessToken: st
 }
 
 export async function updateSigningProfile(profileId: string, payload: CreateSigningProfilePayload, accessToken: string): Promise<void> {
-    const response = await fetch(`${CA_API_BASE_URL}/profiles/${profileId}`, {
+    const response = await fetch(`${get_CA_API_BASE_URL()}/profiles/${profileId}`, {
         method: 'PUT',
         headers: {
             'Content-Type': 'application/json',
@@ -1150,7 +1150,7 @@ export async function updateSigningProfile(profileId: string, payload: CreateSig
 }
 
 export async function deleteSigningProfile(profileId: string, accessToken: string): Promise<void> {
-    const response = await fetch(`${CA_API_BASE_URL}/profiles/${profileId}`, {
+    const response = await fetch(`${get_CA_API_BASE_URL()}/profiles/${profileId}`, {
         method: 'DELETE',
         headers: {
             'Authorization': `Bearer ${accessToken}`

--- a/src/lib/devices-api.ts
+++ b/src/lib/devices-api.ts
@@ -1,7 +1,7 @@
 
 
 // src/lib/devices-api.ts
-import { DEV_MANAGER_API_BASE_URL, handleApiError } from './api-domains';
+import { get_DEV_MANAGER_API_BASE_URL, handleApiError } from './api-domains';
 
 // Interfaces based on usage in components
 export interface ApiDeviceIdentity {
@@ -52,7 +52,7 @@ export interface PatchOperation {
 
 
 export async function fetchDevices(accessToken: string, params: URLSearchParams): Promise<ApiResponse> {
-    const url = `${DEV_MANAGER_API_BASE_URL}/devices?${params.toString()}`;
+    const url = `${get_DEV_MANAGER_API_BASE_URL()}/devices?${params.toString()}`;
     const response = await fetch(url, {
         headers: { 'Authorization': `Bearer ${accessToken}` },
     });
@@ -60,7 +60,7 @@ export async function fetchDevices(accessToken: string, params: URLSearchParams)
 }
 
 export async function fetchDeviceById(deviceId: string, accessToken: string): Promise<ApiDevice> {
-    const url = `${DEV_MANAGER_API_BASE_URL}/devices/${deviceId}`;
+    const url = `${get_DEV_MANAGER_API_BASE_URL()}/devices/${deviceId}`;
     const response = await fetch(url, {
         headers: { 'Authorization': `Bearer ${accessToken}` },
     });
@@ -68,7 +68,7 @@ export async function fetchDeviceById(deviceId: string, accessToken: string): Pr
 }
 
 export async function decommissionDevice(deviceId: string, accessToken: string): Promise<void> {
-    const url = `${DEV_MANAGER_API_BASE_URL}/devices/${deviceId}/decommission`;
+    const url = `${get_DEV_MANAGER_API_BASE_URL()}/devices/${deviceId}/decommission`;
     const response = await fetch(url, {
         method: 'DELETE',
         headers: { 'Authorization': `Bearer ${accessToken}` },
@@ -79,7 +79,7 @@ export async function decommissionDevice(deviceId: string, accessToken: string):
 }
 
 export async function registerDevice(payload: any, accessToken: string): Promise<void> {
-    const url = `${DEV_MANAGER_API_BASE_URL}/devices`;
+    const url = `${get_DEV_MANAGER_API_BASE_URL()}/devices`;
     const response = await fetch(url, {
         method: 'POST',
         headers: {
@@ -94,14 +94,14 @@ export async function registerDevice(payload: any, accessToken: string): Promise
 }
 
 export async function fetchDeviceStats(accessToken: string): Promise<DeviceStats> {
-  const response = await fetch(`${DEV_MANAGER_API_BASE_URL}/stats`, {
+  const response = await fetch(`${get_DEV_MANAGER_API_BASE_URL()}/stats`, {
     headers: { 'Authorization': `Bearer ${accessToken}` },
   });
   return handleApiError(response, 'Failed to fetch device stats');
 }
 
 export async function updateDeviceMetadata(deviceId: string, patchOperations: PatchOperation[], accessToken: string): Promise<void> {
-  const response = await fetch(`${DEV_MANAGER_API_BASE_URL}/devices/${deviceId}/metadata`, {
+  const response = await fetch(`${get_DEV_MANAGER_API_BASE_URL()}/devices/${deviceId}/metadata`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',

--- a/src/lib/dms-api.ts
+++ b/src/lib/dms-api.ts
@@ -1,7 +1,7 @@
 
 // src/lib/dms-api.ts
 
-import { DMS_MANAGER_API_BASE_URL, handleApiError } from './api-domains';
+import { get_DMS_MANAGER_API_BASE_URL, handleApiError } from './api-domains';
 import type { CA } from './ca-data';
 
 // --- Interfaces ---
@@ -86,7 +86,7 @@ export interface RaCreationPayload {
 // --- API Functions ---
 
 export async function fetchRegistrationAuthorities(accessToken: string, params?: URLSearchParams): Promise<ApiRaListResponse> {
-    const url = new URL(`${DMS_MANAGER_API_BASE_URL}/dms`);
+    const url = new URL(`${get_DMS_MANAGER_API_BASE_URL()}/dms`);
     if (params) {
         params.forEach((value, key) => url.searchParams.append(key, value));
     }
@@ -125,7 +125,7 @@ export async function fetchAllRegistrationAuthorities(accessToken: string): Prom
 }
 
 export async function fetchRaById(raId: string, accessToken: string): Promise<ApiRaItem> {
-    const response = await fetch(`${DMS_MANAGER_API_BASE_URL}/dms/${raId}`, {
+    const response = await fetch(`${get_DMS_MANAGER_API_BASE_URL()}/dms/${raId}`, {
         headers: { 'Authorization': `Bearer ${accessToken}` },
     });
     return handleApiError(response, 'Failed to fetch RA details');
@@ -138,8 +138,8 @@ export async function createOrUpdateRa(
     raId?: string | null,
 ): Promise<void> {
     const url = isEditMode
-        ? `${DMS_MANAGER_API_BASE_URL}/dms/${raId}`
-        : `${DMS_MANAGER_API_BASE_URL}/dms`;
+        ? `${get_DMS_MANAGER_API_BASE_URL()}/dms/${raId}`
+        : `${get_DMS_MANAGER_API_BASE_URL()}/dms`;
     const method = isEditMode ? 'PUT' : 'POST';
 
     const response = await fetch(url, {
@@ -162,7 +162,7 @@ export async function createOrUpdateRa(
 
 
 export async function bindIdentityToDevice(deviceId: string, certificateSerialNumber: string, accessToken: string): Promise<void> {
-    const response = await fetch(`${DMS_MANAGER_API_BASE_URL}/dms/bind-identity`, {
+    const response = await fetch(`${get_DMS_MANAGER_API_BASE_URL()}/dms/bind-identity`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -180,7 +180,7 @@ export async function bindIdentityToDevice(deviceId: string, certificateSerialNu
 
 
 export async function fetchDmsStats(accessToken: string): Promise<{ total: number }> {
-    const response = await fetch(`${DMS_MANAGER_API_BASE_URL}/stats`, { 
+    const response = await fetch(`${get_DMS_MANAGER_API_BASE_URL()}/stats`, { 
         headers: { 'Authorization': `Bearer ${accessToken}` } 
     });
     return handleApiError(response, 'Failed to fetch RA stats');

--- a/src/lib/est-api.ts
+++ b/src/lib/est-api.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { EST_API_BASE_URL } from './api-domains';
+import { get_EST_API_BASE_URL } from './api-domains';
 
 /**
  * Fetches CA certificates from the EST endpoint for a given RA.
@@ -14,7 +14,7 @@ export async function fetchEstCaCerts(
     format: 'pkcs7-mime' | 'x-pem-file',
     accessToken?: string
 ): Promise<{ data: ArrayBuffer | string, contentType: string }> {
-    const url = `${EST_API_BASE_URL}/${raId}/cacerts`;
+    const url = `${get_EST_API_BASE_URL()}/${raId}/cacerts`;
 
     const headers: HeadersInit = {
         'Accept': `application/${format}`,

--- a/src/lib/issued-certificate-data.ts
+++ b/src/lib/issued-certificate-data.ts
@@ -1,5 +1,5 @@
 import type { CertificateData } from '@/types/certificate';
-import { CA_API_BASE_URL } from './api-domains';
+import { get_CA_API_BASE_URL } from './api-domains';
 import { parseCertificatePemDetails } from './ca-data';
 
 
@@ -129,8 +129,8 @@ export async function fetchIssuedCertificates(
   const { accessToken, apiQueryString, forCaId } = params;
   
   const baseUrl = forCaId
-    ? `${CA_API_BASE_URL}/cas/${forCaId}/certificates`
-    : `${CA_API_BASE_URL}/certificates`;
+    ? `${get_CA_API_BASE_URL()}/cas/${forCaId}/certificates`
+    : `${get_CA_API_BASE_URL()}/certificates`;
   
   const finalQueryString = apiQueryString || 'sort_by=valid_from&sort_mode=desc&page_size=10';
 
@@ -195,7 +195,7 @@ export async function updateCertificateStatus({
   // The API endpoint expects the serial number with hyphens instead of colons.
   const apiFormattedSerialNumber = serialNumber.replace(/:/g, '-');
   
-  const response = await fetch(`${CA_API_BASE_URL}/certificates/${apiFormattedSerialNumber}/status`, {
+  const response = await fetch(`${get_CA_API_BASE_URL()}/certificates/${apiFormattedSerialNumber}/status`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
@@ -218,7 +218,7 @@ export async function updateCertificateStatus({
 
 export async function updateCertificateMetadata(serialNumber: string, metadata: object, accessToken: string): Promise<void> {
   const apiFormattedSerialNumber = serialNumber.replace(/:/g, '-');
-  const response = await fetch(`${CA_API_BASE_URL}/certificates/${apiFormattedSerialNumber}/metadata`, {
+  const response = await fetch(`${get_CA_API_BASE_URL()}/certificates/${apiFormattedSerialNumber}/metadata`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',

--- a/src/lib/va-api.ts
+++ b/src/lib/va-api.ts
@@ -1,6 +1,6 @@
 
 // src/lib/va-api.ts
-import { VA_API_BASE_URL, VA_CORE_API_BASE_URL, handleApiError } from './api-domains';
+import { get_VA_API_BASE_URL, get_VA_CORE_API_BASE_URL, handleApiError } from './api-domains';
 
 export interface VAConfig {
   caId: string;
@@ -39,7 +39,7 @@ export interface VaUpdatePayload {
  * Throws an error for other failures.
  */
 export async function fetchVaConfig(ski: string, accessToken: string): Promise<VaApiResponse | null> {
-    const response = await fetch(`${VA_API_BASE_URL}/roles/${ski}`, {
+    const response = await fetch(`${get_VA_API_BASE_URL()}/roles/${ski}`, {
         headers: { 'Authorization': `Bearer ${accessToken}` },
     });
 
@@ -55,7 +55,7 @@ export async function fetchVaConfig(ski: string, accessToken: string): Promise<V
  * Creates or updates the VA configuration for a given CA Subject Key ID (SKI).
  */
 export async function updateVaConfig(ski: string, payload: VaUpdatePayload, accessToken: string): Promise<void> {
-    const response = await fetch(`${VA_API_BASE_URL}/roles/${ski}`, {
+    const response = await fetch(`${get_VA_API_BASE_URL()}/roles/${ski}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -76,7 +76,7 @@ export async function updateVaConfig(ski: string, payload: VaUpdatePayload, acce
  * Returns the CRL data as an ArrayBuffer.
  */
 export async function downloadCrl(ski: string, accessToken: string): Promise<ArrayBuffer> {
-    const response = await fetch(`${VA_CORE_API_BASE_URL}/crl/${ski}`, {
+    const response = await fetch(`${get_VA_CORE_API_BASE_URL()}/crl/${ski}`, {
         headers: {
             'Authorization': `Bearer ${accessToken}`,
             'Accept': 'application/pkix-crl',


### PR DESCRIPTION
This pull request introduces several improvements and refactors across the codebase, focusing on configuration management, environment variable handling, UI consistency, and minor usability enhancements. The most significant changes are the introduction of a centralized `ConfigContext` for configuration values, refactoring API base URL usage for better flexibility, and updates to UI logic to rely on the new configuration context.

**Configuration Management Improvements:**

* Introduced `ConfigProvider` and `useConfig` from `ConfigContext`, and wrapped the app in `ConfigProvider` in `src/app/layout.tsx` to provide configuration values throughout the app. Updated imports and usages to use the new context instead of accessing `window.lamassuConfig` directly. [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R7) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R29) [[3]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R522-R529) [[4]](diffhunk://#diff-43d5a7377229e2555624d2b52a223a8960d2826598e67909741b88f1973e1fc8R11) [[5]](diffhunk://#diff-43d5a7377229e2555624d2b52a223a8960d2826598e67909741b88f1973e1fc8R20) [[6]](diffhunk://#diff-cf239e897193b2687998acaf21bc04a2e009dcf7253005cdf7fb92da6afc25fbR7)

* Refactored the footer logic in `src/app/layout.tsx` to show or hide the footer and load its content based on the new config context, improving reliability and maintainability.

* Updated the integration creation logic in `src/app/integrations/new/page.tsx` to load connector definitions from the config context, with a fallback to environment variables, and made the effect reactive to config changes.

**API Environment Variable Refactoring:**

* Replaced direct usage of API base URL constants (e.g., `EST_API_BASE_URL`, `DMS_MANAGER_API_BASE_URL`) with getter functions (e.g., `get_EST_API_BASE_URL()`) throughout the codebase for more flexible and dynamic environment variable handling. This affects device registration, backend status dialogs, EST enroll/re-enroll modals, and registration authority CA certs pages. [[1]](diffhunk://#diff-87d863c0dfde00bee48d0a52492d49d865d2025f2d05bde92e26bfc7a97dabb8L15-R15) [[2]](diffhunk://#diff-87d863c0dfde00bee48d0a52492d49d865d2025f2d05bde92e26bfc7a97dabb8L131-R132) [[3]](diffhunk://#diff-71f17d396c1ab7f25297761e26b0b2592efdbf8661d8a1733d23ceefc50f4a0bL17-R17) [[4]](diffhunk://#diff-71f17d396c1ab7f25297761e26b0b2592efdbf8661d8a1733d23ceefc50f4a0bL101-R101) [[5]](diffhunk://#diff-dd8c9bf4832af541dbdcf189ff1f644daa49f615efce4c3164508f1412097eb2L11-R15) [[6]](diffhunk://#diff-dd8c9bf4832af541dbdcf189ff1f644daa49f615efce4c3164508f1412097eb2L37-R41) [[7]](diffhunk://#diff-fe7673d4c411b7ea0a48937a56cc470562c2f91adab57193cc98f52a2c38869dL19-R19) [[8]](diffhunk://#diff-fe7673d4c411b7ea0a48937a56cc470562c2f91adab57193cc98f52a2c38869dL324-R324) [[9]](diffhunk://#diff-fe7673d4c411b7ea0a48937a56cc470562c2f91adab57193cc98f52a2c38869dL336-R336) [[10]](diffhunk://#diff-71f74750680e2d5d4da94f78b665c4ff45683b9002f3eecf8dc96fcf960a9c99L14-R14) [[11]](diffhunk://#diff-71f74750680e2d5d4da94f78b665c4ff45683b9002f3eecf8dc96fcf960a9c99L165-R165)

**UI and Usability Enhancements:**

* Changed the toast notification variant for duplicate integration warning from "warning" to "destructive" in `src/app/integrations/new/page.tsx` for better user feedback.

* Adjusted sidebar inset padding for better layout spacing in `src/app/layout.tsx`.

**Developer Experience:**

* Added debug logging for layout rendering and mounting in `src/app/layout.tsx` to assist with troubleshooting and development. [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R220-R224) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R471-R475)

**Project Structure:**

* Added a comprehensive `.dockerignore` file to improve Docker build performance and security by excluding unnecessary files and directories.