### PR TITLE
fix: update OIDC authority variable syntax to allow js evaluation

### DIFF
--- a/config.js.tmpl
+++ b/config.js.tmpl
@@ -28,7 +28,7 @@ window.lamassuConfig = {
     // The OIDC provider's URL. All OIDC endpoints (.well-known, authorization, token)
     // are relative to this authority.
     // Example: "https://auth.yourdomain.com/realms/your-realm"
-    LAMASSU_AUTH_AUTHORITY: "${OIDC_AUTHORITY}",
+    LAMASSU_AUTH_AUTHORITY: `${OIDC_AUTHORITY}`,
     
     // The OIDC client ID registered with your provider for this frontend application.
     LAMASSU_AUTH_CLIENT_ID: "${OIDC_CLIENT_ID}",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextn",
-  "version": "4.0.0",
+  "version": "4.0.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack -p 9002",


### PR DESCRIPTION
This pull request contains two small changes: a minor update to the syntax in the configuration template and a version bump in the package manifest.

- Configuration improvement:
  * Updated the `LAMASSU_AUTH_AUTHORITY` assignment in `config.js.tmpl` to use template literal syntax for consistency.

- Maintenance:
  * Bumped the version in `package.json` from `4.0.0` to `4.0.2`.