### PR TITLE
feat: allow to delete a decommissioned device

### DIFF
--- a/src/components/shared/DeleteDeviceModal.tsx
+++ b/src/components/shared/DeleteDeviceModal.tsx
@@ -1,0 +1,65 @@
+
+'use client';
+
+import React from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { buttonVariants } from "@/components/ui/button";
+import { AlertTriangle, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface DeleteDeviceModalProps {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  onConfirm: () => void;
+  deviceName: string;
+  isDeleting: boolean;
+}
+
+export const DeleteDeviceModal: React.FC<DeleteDeviceModalProps> = ({
+  isOpen,
+  onOpenChange,
+  onConfirm,
+  deviceName,
+  isDeleting,
+}) => {
+  return (
+    <AlertDialog open={isOpen} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Permanently Delete Device</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently remove the device from the system. This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <Alert variant="warning" className="bg-red-50 border-red-200 dark:bg-red-900/20 dark:border-red-800">
+            <AlertTriangle className="h-4 w-4 text-red-500" />
+            <AlertTitle className="text-red-700 dark:text-red-300">Warning: Irreversible Action</AlertTitle>
+            <AlertDescription className="text-red-600 dark:text-red-400">
+                You are about to permanently delete the device "{deviceName}". This is only possible for decommissioned devices. Are you sure you want to proceed?
+            </AlertDescription>
+        </Alert>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            className={cn(buttonVariants({ variant: "destructive" }))}
+            disabled={isDeleting}
+          >
+            {isDeleting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Delete Permanently
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/src/lib/devices-api.ts
+++ b/src/lib/devices-api.ts
@@ -114,3 +114,14 @@ export async function updateDeviceMetadata(deviceId: string, patchOperations: Pa
     await handleApiError(response, 'Failed to update device metadata');
   }
 }
+
+export async function deleteDevice(deviceId: string, accessToken: string): Promise<void> {
+    const url = `${get_DEV_MANAGER_API_BASE_URL()}/devices/${deviceId}`;
+    const response = await fetch(url, {
+        method: 'DELETE',
+        headers: { 'Authorization': `Bearer ${accessToken}` },
+    });
+    if (!response.ok) {
+        await handleApiError(response, 'Failed to delete device');
+    }
+}


### PR DESCRIPTION
This pull request introduces the ability to permanently delete decommissioned devices from the system, along with several improvements to device integration handling and user interface updates. The most significant changes are the addition of a permanent deletion workflow, enhancements to how integrations are managed and displayed, and related UI/UX updates.

**Permanent Device Deletion Feature:**

* Added a new `DeleteDeviceModal` component to confirm and warn users before permanently deleting a device. This modal is only available for decommissioned devices.
* Implemented the `deleteDevice` API function in `devices-api.ts` to handle device deletion requests to the backend.
* Integrated the permanent deletion workflow into `DeviceDetailsClient.tsx`, including new state management, event handlers, and UI controls for deletion. The UI now shows a "Permanently Delete" button for decommissioned devices, triggers the modal, and handles deletion feedback and redirection. [[1]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cL28-R29) [[2]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cR94-R100) [[3]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cR684-R689) [[4]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cR932-R947) [[5]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cL531-R576)

**Device Integration Handling Improvements:**

* Updated the logic for loading integrations: now supports multiple integrations per device, stores them in `availableIntegrations`, and selects a default active integration. [[1]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cL126-R146) [[2]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cR182)
* Updated the force update workflow to allow selection among available integrations and pass the correct configuration key. [[1]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cL540-R585) [[2]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cR932-R947)

**User Interface and Experience Updates:**

* Improved button layout for device actions using `flex-wrap` and `gap` for better responsiveness and appearance.
* After decommissioning a device, the details are refreshed instead of redirecting immediately, allowing for follow-up actions like permanent deletion.

These changes collectively enhance device lifecycle management by allowing for safe, explicit, and irreversible removal of devices, while also improving the flexibility and clarity of device integration operations.