### PR TITLE
fix: va: use private API base URL for VA endpoints

### DIFF
--- a/src/lib/api-domains.ts
+++ b/src/lib/api-domains.ts
@@ -16,7 +16,7 @@ const getApiBaseUrl = (): string => {
     return '';
 };
 
-const getVaEstApiBaseUrl = (): string => {
+const getEstApiBaseUrl = (): string => {
     // 1. Check for the specific override for VA/EST endpoints
     if (typeof window !== 'undefined' && (window as any).lamassuConfig?.LAMASSU_PUBLIC_API) {
         return (window as any).lamassuConfig.LAMASSU_PUBLIC_API;
@@ -29,11 +29,11 @@ export const get_CA_API_BASE_URL = () => `${getApiBaseUrl()}/ca/v1`;
 export const get_DEV_MANAGER_API_BASE_URL = () => `${getApiBaseUrl()}/devmanager/v1`;
 export const get_DMS_MANAGER_API_BASE_URL = () => `${getApiBaseUrl()}/dmsmanager/v1`;
 export const get_ALERTS_API_BASE_URL = () => `${getApiBaseUrl()}/alerts/v1`;
+export const get_VA_CORE_API_BASE_URL = () => `${getApiBaseUrl()}/va`;
+export const get_VA_API_BASE_URL = () => `${get_VA_CORE_API_BASE_URL()}/v1`;
 
 // These endpoints now use the potentially overridden base URL
-export const get_EST_API_BASE_URL = () => `${getVaEstApiBaseUrl()}/dmsmanager/.well-known/est`;
-export const get_VA_CORE_API_BASE_URL = () => `${getVaEstApiBaseUrl()}/va`;
-export const get_VA_API_BASE_URL = () => `${get_VA_CORE_API_BASE_URL()}/v1`;
+export const get_EST_API_BASE_URL = () => `${getEstApiBaseUrl()}/dmsmanager/.well-known/est`;
 
 export const handleApiError = async (response: Response, defaultMessage: string) => {
     if (!response.ok) {


### PR DESCRIPTION
This PR corrects the base URL configuration for Validation Authority (VA) endpoints to use the private API base URL instead of the public API base URL, ensuring proper service communication within the internal network infrastructure.