### PR TITLE
fix: show revocation reason at CRL modal

### DIFF
--- a/src/lib/revocation-reasons.ts
+++ b/src/lib/revocation-reasons.ts
@@ -1,63 +1,68 @@
 
 export interface RevocationReason {
-  value: string;
+  value: int;
   label: string;
   description: string;
 }
 
 export const revocationReasons: RevocationReason[] = [
   {
-    value: "Unspecified",
+    value: 0,
     label: "Unspecified",
     description: "Revocation occurred for a reason that has no more specific value.",
   },
   {
-    value: "KeyCompromise",
+    value: 1,
     label: "KeyCompromise",
     description: "The private key, or another validated portion of an end-entity certificate, is suspected to have been compromised.",
   },
   {
-    value: "CACompromise",
+    value: 2,
     label: "CACompromise",
     description: "The private key, or another validated portion of a Certificate Authority (CA) certificate, is suspected to have been compromised.",
   },
   {
-    value: "AffiliationChanged",
+    value: 3,
     label: "AffiliationChanged",
     description: "The subject's name, or other validated information in the certificate, has changed without anything being compromised.",
   },
   {
-    value: "Superseded",
+    value: 4,
     label: "Superseded",
     description: "The certificate has been superseded, but without anything being compromised.",
   },
   {
-    value: "CessationOfOperation",
+    value: 5,
     label: "CessationOfOperation",
     description: "The certificate is no longer needed, but nothing is suspected to be compromised.",
   },
   {
-    value: "CertificateHold",
+    value: 6,
     label: "CertificateHold",
     description: "The certificate is temporarily suspended, and may either return to service or become permanently revoked in the future.",
   },
   {
-    value: "RemoveFromCRL",
+    value: 7,
+    label: "Unexpected value",
+    description: "(7) is reserved and not used by RFC.",
+  },
+  {
+    value: 8,
     label: "RemoveFromCRL",
     description: "The certificate was revoked with CertificateHold on a base Certificate Revocation List (CRL) and is being returned to service on a delta CRL.",
   },
   {
-    value: "PrivilegeWithdrawn",
+    value: 9,
     label: "PrivilegeWithdrawn",
     description: "A privilege contained within the certificate has been withdrawn.",
   },
   {
-    value: "AACompromise",
+    value: 10,
     label: "AACompromise",
     description: "It is known, or suspected, that aspects of the Attribute Authority (AA) validated in the attribute certificate have been compromised.",
   },
   {
-    value: "WeakAlgorithmOrKey",
+    value: 11,
     label: "WeakAlgorithmOrKey",
     description: "The certificate key uses a weak cryptographic algorithm, or the key is too short, or the key was generated in an unsafe manner.",
   },


### PR DESCRIPTION
This pull request updates the `RevocationReason` type and the `revocationReasons` array to use integer values instead of strings for each revocation reason. It also adds a new entry for the reserved value 7, clarifying its status per RFC.

Type and data structure changes:

* Changed the `value` property in the `RevocationReason` interface from `string` to `int` in `src/lib/revocation-reasons.ts`.
* Updated all entries in `revocationReasons` to use integer values instead of string identifiers for each revocation reason.

RFC compliance improvements:

* Added a new entry for value 7, labeled "Unexpected value", to indicate that this value is reserved and not used according to RFC.

Fix #113
