### PR TITLE
feat: enhance certificate details display with revocation reason badge

### DIFF
--- a/src/app/certificates/details/CertificateDetailsClient.tsx
+++ b/src/app/certificates/details/CertificateDetailsClient.tsx
@@ -426,9 +426,16 @@ export default function CertificateDetailsClient() { // Renamed component
                 Serial Number: {certificateDetails.serialNumber}
               </p>
             </div>
-            <Badge variant={statusVariant} className={cn("text-sm self-start sm:self-auto mt-2 sm:mt-0", statusVariant !== 'outline' ? statusColorClass : '')}>
+            <div className="flex items-center gap-2 self-start sm:self-auto mt-2 sm:mt-0">
+              <Badge variant={statusVariant} className={cn("text-sm", statusVariant !== 'outline' ? statusColorClass : '')}>
                 {statusText}
-            </Badge>
+              </Badge>
+              {statusText === 'REVOKED' && certificateDetails.revocationReason && (
+                <Badge variant="outline" className="text-sm text-muted-foreground">
+                  {certificateDetails.revocationReason}
+                </Badge>
+              )}
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
This pull request introduces a minor UI enhancement to the certificate details page. The main update is the addition of a new badge that displays the revocation reason for certificates that have been revoked.

UI improvements:

* In `CertificateDetailsClient`, a new badge is conditionally rendered to show the `revocationReason` when the certificate status is `REVOKED`, improving visibility of revocation details for users.

Fix #111
