### PR TITLE
fix: remove sourounding box at the filter section on the CAs page

### DIFF
--- a/src/app/certificate-authorities/page.tsx
+++ b/src/app/certificate-authorities/page.tsx
@@ -1,5 +1,4 @@
 
-
 'use client';
 
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
@@ -186,7 +185,7 @@ export default function CertificateAuthoritiesPage() {
           </div>
           <p className="text-sm text-muted-foreground mb-4">Manage your Certification Authority configurations and trust stores.</p> 
 
-          <div className="flex flex-col md:flex-row gap-4 items-end mb-4 p-4 border rounded-lg bg-muted/30">
+          <div className="flex flex-col md:flex-row gap-4 items-end mb-4">
             <div className="flex-grow w-full space-y-1.5">
                 <Label htmlFor="ca-filter">Filter by Name</Label>
                 <div className="relative">


### PR DESCRIPTION
This pull request makes a couple of small changes to the `src/app/certificate-authorities/page.tsx` file. The changes include removing an unnecessary `'use client';` directive and simplifying the styling of a filter section by removing extra padding, border, and background classes.

- Cleanup and Styling Adjustments:
  * Removed the `'use client';` directive, which was likely unnecessary in this context.
  * Simplified the filter section's container by removing padding, border, and background utility classes, resulting in a cleaner UI.