### PR TITLE
fix: Improve Dark Mode Contrast

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -354,3 +354,7 @@
     filter: grayscale(100%) invert(100%);
   }
 }
+
+.dark .text-primary {
+  color: hsl(217 100% 70%);
+}


### PR DESCRIPTION
This pull request introduces a small styling update to the global CSS. Specifically, it adds a new color definition for the `.text-primary` class when in dark mode.

* Added a `.dark .text-primary` selector to `src/app/globals.css` to set the text color to `hsl(217 100% 70%)` for improved visibility in dark mode.