### PR TITLE
feat: Make certificate filters case-insensitive to improve search accuracy

### DIFF
--- a/src/app/certificates/details/CertificateDetailsClient.tsx
+++ b/src/app/certificates/details/CertificateDetailsClient.tsx
@@ -138,7 +138,7 @@ export default function CertificateDetailsClient() { // Renamed component
       const apiFormattedSerialNumber = certificateId.replace(/:/g, '');
       const { certificates: certList } = await fetchIssuedCertificates({ 
           accessToken: user.access_token, 
-          apiQueryString: `filter=serial_number[equal]${apiFormattedSerialNumber}&page_size=1`
+          apiQueryString: `filter=serial_number[equal_ignorecase]${apiFormattedSerialNumber}&page_size=1`
       });
       const foundCert = certList.length > 0 ? certList[0] : null;
       

--- a/src/app/devices/details/DeviceDetailsClient.tsx
+++ b/src/app/devices/details/DeviceDetailsClient.tsx
@@ -256,7 +256,7 @@ export default function DeviceDetailsClient() {
             const certPromises = pageIdentities.map(async ({ version, serialNumber }) => {
                 const { certificates } = await fetchIssuedCertificates({
                     accessToken: user.access_token!,
-                    apiQueryString: `filter=serial_number[equal]${serialNumber}&page_size=1`
+                    apiQueryString: `filter=serial_number[equal_ignorecase]${serialNumber}&page_size=1`
                 });
                 const certData = certificates[0];
                 if (!certData) return null;

--- a/src/components/home/InitializationWizard.tsx
+++ b/src/components/home/InitializationWizard.tsx
@@ -270,7 +270,7 @@ export const InitializationWizard: React.FC = () => {
                     const createdCaList = await fetchAndProcessCAs(user.access_token, `filter=id[equal]${testCaId}`);
                     const { certificates } = await fetchIssuedCertificates({
                         accessToken: user.access_token,
-                        apiQueryString: `filter=serial_number[equal]${issuedCertSerialNumber}&page_size=1`
+                        apiQueryString: `filter=serial_number[equal_ignorecase]${issuedCertSerialNumber}&page_size=1`
                     });
                     const issuedCertDetails = certificates[0];
                     if (!issuedCertDetails?.pemData || createdCaList.length === 0 || !createdCaList[0].pemData) {

--- a/src/components/shared/CertificateSelectorModal.tsx
+++ b/src/components/shared/CertificateSelectorModal.tsx
@@ -101,9 +101,9 @@ export const CertificateSelectorModal: React.FC<CertificateSelectorModalProps> =
       }
       if (debouncedSearchTerm.trim() !== '') {
         if (searchField === 'commonName') {
-          filtersToApply.push(`subject.common_name[contains]${debouncedSearchTerm.trim()}`);
+          filtersToApply.push(`subject.common_name[contains_ignorecase]${debouncedSearchTerm.trim()}`);
         } else if (searchField === 'serialNumber') {
-          filtersToApply.push(`serial_number[contains]${debouncedSearchTerm.trim()}`);
+          filtersToApply.push(`serial_number[contains_ignorecase]${debouncedSearchTerm.trim()}`);
         }
       }
       filtersToApply.forEach(f => params.append('filter', f));

--- a/src/hooks/usePaginatedCertificateFetcher.ts
+++ b/src/hooks/usePaginatedCertificateFetcher.ts
@@ -113,7 +113,7 @@ export function usePaginatedCertificateFetcher({ caId = null, initialPageSize = 
                 if (searchField === 'commonName') {
                     filtersToApply.push(`subject.common_name[contains]${debouncedSearchTerm.trim()}`);
                 } else if (searchField === 'serialNumber') {
-                    filtersToApply.push(`serial_number[contains]${debouncedSearchTerm.trim()}`);
+                    filtersToApply.push(`serial_number[contains_ignorecase]${debouncedSearchTerm.trim()}`);
                 }
             }
             filtersToApply.forEach(f => apiParams.append('filter', f));


### PR DESCRIPTION
This pull request updates certificate filtering logic throughout the codebase to improve search accuracy and consistency. The main change is replacing case-sensitive serial number and common name filters with case-insensitive versions, ensuring that searches work regardless of letter casing.

**Certificate filtering improvements:**

* Updated all usages of `serial_number[equal]` and `serial_number[contains]` filters to use their case-insensitive counterparts (`equal_ignorecase` and `contains_ignorecase`) in certificate fetching functions, improving robustness of certificate lookups. [[1]](diffhunk://#diff-a547ea5bd303aaa76e08165cd0690af40776cc7df25003cb37e787f65380b68fL141-R141) [[2]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cL259-R259) [[3]](diffhunk://#diff-1f3d49cb42edda2720a90639bdc253af22dddf5978f375cce9c1b0c4b21cbb93L273-R273) [[4]](diffhunk://#diff-612847e5fd162ed6882ff190497e3fadddd02a46fd98e3eda928800d22eaea96L104-R106) [[5]](diffhunk://#diff-ac6c1edcb797cca85e1038f31c2639999af25110496e86a65b0f7b564e7e0270L116-R116)
* Changed the `commonName` filter in certificate search modals and hooks from `contains` to `contains_ignorecase`, allowing users to search for certificates without worrying about case sensitivity. [[1]](diffhunk://#diff-612847e5fd162ed6882ff190497e3fadddd02a46fd98e3eda928800d22eaea96L104-R106) [[2]](diffhunk://#diff-ac6c1edcb797cca85e1038f31c2639999af25110496e86a65b0f7b564e7e0270L116-R116)