### PR TITLE
fix: openssl rsa pss sign with pkcs11 & full chain pem display

### DIFF
--- a/src/app/certificate-authorities/details/CertificateAuthorityDetailsClient.tsx
+++ b/src/app/certificate-authorities/details/CertificateAuthorityDetailsClient.tsx
@@ -172,7 +172,7 @@ export default function CertificateAuthorityDetailsClient() {
   
           const path = buildCaPathToRoot(foundCa.id, allCertificateAuthoritiesData);
           setCaPathToRoot(path);
-          const chainPem = path.map(p => p.pemData).filter(Boolean).join('\\n\\n');
+          const chainPem = path.slice().reverse().map(p => p.pemData).filter(Boolean).join('');
           setFullChainPemString(chainPem);
           if (isAuthenticated() && user?.access_token) {
               loadCaStats(foundCa.id, user.access_token);

--- a/src/app/certificates/details/CertificateDetailsClient.tsx
+++ b/src/app/certificates/details/CertificateDetailsClient.tsx
@@ -53,7 +53,7 @@ const buildCertificateChainPem = (
     currentIssuerId = issuerCa.issuer;
     safetyNet++;
   }
-  return chain.join('\\n\\n'); 
+  return chain.join(''); 
 };
 
 

--- a/src/components/kms/details/KmsCliOperations.tsx
+++ b/src/components/kms/details/KmsCliOperations.tsx
@@ -191,7 +191,7 @@ export OPENSSL_CONF=$(pwd)/openssl-pkcs11-provider.conf`;
     const getOpensslSignCommand = (isEngine: boolean) => {
         const opensslFlags = isEngine ? '-engine pkcs11' : '-provider pkcs11 -provider default';
         const isPssAlgorithm = selectedAlgorithm.includes('PSS');
-        const pssOption = isPssAlgorithm ? '-pkeyopt rsa_padding_mode:pss' : '';
+        const pssOption = isPssAlgorithm ? `-pkeyopt rsa_padding_mode:pss -pkeyopt digest:${hashAlgorithm}` : '';
 
         return inputType === 'digest'
             ? `echo -n "your-data-to-sign" | openssl dgst -${hashAlgorithm} -binary -out digest.bin
@@ -202,7 +202,7 @@ echo "signed data digest: $(cat digest.bin | hexdump -v -e '/1 "%02x"')"
 echo "signature result (base64 encoded): $(cat signature.bin | base64 -w 0)"
 `
             : `echo -n "your-data-to-sign" | \\
-openssl dgst -${hashAlgorithm} -sign "pkcs11:label=${keyAliasSanitized};type=private" ${isPssAlgorithm ? '-sigopt rsa_padding_mode:pss \\' : ''} ${opensslFlags} -out signature.bin
+openssl dgst -${hashAlgorithm} -sign "pkcs11:label=${keyAliasSanitized};type=private" ${isPssAlgorithm ? '-sigopt rsa_padding_mode:pss' : ''} ${opensslFlags} -out signature.bin
 
 echo "signature result (base64 encoded): $(cat signature.bin | base64 -w 0)"`
     };


### PR DESCRIPTION
This pull request introduces changes to certificate chain formatting and OpenSSL command generation, primarily to improve compatibility and correctness in cryptographic operations. The most important updates include modifying how certificate chains are concatenated and refining OpenSSL commands for RSA-PSS signatures to specify the digest algorithm.

**Certificate Chain Formatting:**
* The concatenation of certificate chains in both `CertificateAuthorityDetailsClient.tsx` and `CertificateDetailsClient.tsx` was changed to remove newline separators, resulting in a single continuous PEM string. This may improve compatibility with systems expecting a single PEM block. [[1]](diffhunk://#diff-b36220efa135c0e167a3c638dfe85f05d6eea40f245acd50731df68a38c2b0e6L175-R175) [[2]](diffhunk://#diff-a547ea5bd303aaa76e08165cd0690af40776cc7df25003cb37e787f65380b68fL56-R56)

**OpenSSL Command Generation:**
* In `KmsCliOperations.tsx`, the OpenSSL command for RSA-PSS signatures now explicitly includes the digest algorithm using `-pkeyopt digest:${hashAlgorithm}` for improved cryptographic correctness.
* The command for signing data with OpenSSL was simplified by removing the unnecessary trailing backslash after the `-sigopt rsa_padding_mode:pss` option, ensuring proper command execution.