### PR TITLE
chore: prepare for next release  4.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lamassu-dashboard",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack -p 9002",


### PR DESCRIPTION
This pull request updates the version of the `lamassu-dashboard` package. No other changes are included.

- Bumped the version in `package.json` from `4.1.3` to `4.1.4`.