### PR TITLE
fix: replace IdentifierDisplay with inline text for Key ID display

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -21,10 +21,10 @@
     /* Custom header foreground */
     --header-height: 3rem;
 
-    --accent: 150 65% 85%;
-    /* #a2ecc8 Periwinkle (greenish) */
-    --accent-foreground: 150 65% 25%;
-    /* Darker accent for contrast */
+    --accent: 210 80% 92%;
+    /* Light blue accent */
+    --accent-foreground: 210 80% 25%;
+    /* Darker blue for contrast */
 
     /* Standard ShadCN UI Colors (derived) */
     --card: 0 0% 100%;
@@ -86,10 +86,10 @@
     /* Same as main primary */
     --sidebar-primary-foreground: 0 0% 98%;
     /* Same as main primary-foreground */
-    --sidebar-accent: 150 65% 80%;
-    /* Slightly adjusted accent */
-    --sidebar-accent-foreground: 150 65% 20%;
-    /* Darker accent */
+    --sidebar-accent: 210 80% 90%;
+    /* Light blue accent */
+    --sidebar-accent-foreground: 210 80% 25%;
+    /* Darker blue */
     --sidebar-border: 210 40% 85%;
     /* Sidebar border */
     --sidebar-ring: 217 90% 65%;

--- a/src/app/kms/keys/details/KmsKeyDetailsClient.tsx
+++ b/src/app/kms/keys/details/KmsKeyDetailsClient.tsx
@@ -32,7 +32,6 @@ import { KeyStrengthIndicator } from '@/components/shared/KeyStrengthIndicator';
 import { SectionHeader } from '@/components/shared/FormComponents';
 import { KmsCliOperations } from '@/components/kms/details/KmsCliOperations';
 import { TagInput } from '@/components/shared/TagInput';
-import { IdentifierDisplay } from '@/components/shared/IdentifierDisplay';
 
 // Monaco Editor dynamic import
 const Editor = dynamic(() => import('@monaco-editor/react'), { 
@@ -1059,7 +1058,7 @@ export default function KmsKeyDetailsClient() {
                 </h1>
               </div>
               <p className="text-sm text-muted-foreground mt-1.5">
-                Key ID: <IdentifierDisplay value={keyDetails.id} className="text-xs" />
+                Key ID: <span className="font-mono text-xs">{keyDetails.id}</span>
               </p>
             </div>
           </div>
@@ -1097,7 +1096,7 @@ export default function KmsKeyDetailsClient() {
                     <div className="space-y-2">
                       <Label className="text-sm font-medium text-muted-foreground">Key Identifier</Label>
                       <div className="p-3 bg-muted/30 rounded-lg border">
-                        <IdentifierDisplay value={keyDetails.id} className="text-xs" />
+                        <div className="font-mono text-xs">{keyDetails.id}</div>
                       </div>
                     </div>
                     


### PR DESCRIPTION
This pull request updates the accent color theme across the application to use a light blue instead of green, and simplifies the display of key identifiers in the key details view by removing the `IdentifierDisplay` component in favor of inline rendering. These changes improve visual consistency and reduce component complexity.

**Theme updates:**

* Changed primary accent and sidebar accent colors in `globals.css` from green (`150 65% ...`) to light blue (`210 80% ...`), including foregrounds for better contrast. [[1]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412L24-R27) [[2]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412L89-R92)

**Component simplification:**

* Removed the import and usage of the `IdentifierDisplay` component in `KmsKeyDetailsClient.tsx`, replacing it with a simple `span` or `div` using `font-mono text-xs` for displaying key IDs. [[1]](diffhunk://#diff-3abb217bbd91e6d536842734c5f9f2772afe4498e6b6a5941c7716ad9631f716L35) [[2]](diffhunk://#diff-3abb217bbd91e6d536842734c5f9f2772afe4498e6b6a5941c7716ad9631f716L1062-R1061) [[3]](diffhunk://#diff-3abb217bbd91e6d536842734c5f9f2772afe4498e6b6a5941c7716ad9631f716L1100-R1099)