### PR TITLE
feat: only logout if the error is fatal and requires user interaction

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -141,16 +141,29 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
     const onUserLoaded = (loadedUser: User) => setUser(loadedUser);
     const onUserUnloaded = () => setUser(null);
-    const onSilentRenewError = (error: Error) => { console.error("AuthContext: Silent renew error:", error); logout(); };
+    const onSilentRenewError = (error: Error) => {
+      console.error("AuthContext: Silent renew error:", error);
+      // Only logout if the error is fatal and requires user interaction
+      const fatalErrors = ['login_required', 'interaction_required', 'invalid_grant'];
+      if (fatalErrors.some(e => error.message.includes(e))) {
+        logout();
+      }
+    };
+    const onAccessTokenExpired = () => {
+      console.warn("AuthContext: Access token expired. Logging out.");
+      logout();
+    }
 
     userManagerInstance.events.addUserLoaded(onUserLoaded);
     userManagerInstance.events.addUserUnloaded(onUserUnloaded);
     userManagerInstance.events.addSilentRenewError(onSilentRenewError);
+    userManagerInstance.events.addAccessTokenExpired(onAccessTokenExpired);
 
     return () => {
       userManagerInstance.events.removeUserLoaded(onUserLoaded);
       userManagerInstance.events.removeUserUnloaded(onUserUnloaded);
       userManagerInstance.events.removeSilentRenewError(onSilentRenewError);
+      userManagerInstance.events.removeAccessTokenExpired(onAccessTokenExpired);
     };
   }, [userManagerInstance, authMode, logout]);
 


### PR DESCRIPTION
This pull request updates the authentication event handling logic in the `AuthProvider` component to improve how user logout is triggered in response to authentication errors and token expiration.

Authentication event handling improvements:

* Updated the `onSilentRenewError` handler to only trigger logout for fatal errors that require user interaction, such as `'login_required'`, `'interaction_required'`, and `'invalid_grant'`, rather than logging out on any silent renew error.
* Added a new `onAccessTokenExpired` handler to log out the user when the access token expires, ensuring users are logged out promptly when their session is no longer valid.
* Registered and cleaned up the new `onAccessTokenExpired` event handler with the `userManagerInstance` to ensure proper resource management.