### PR TITLE
Improve authentication handling in develop mode, error messaging, and test coverage

### DIFF
--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -85,7 +85,7 @@ export default function IntegrationsPage() {
 
   const handleDeleteIntegration = async () => {
     if (!integrationToDelete) {
-      sileo.error({ title: "Error", description: "No integration selected or user not authenticated." });
+      sileo.error({ title: "Error", description: "No integration selected." });
       return;
     }
     setIsDeleting(true);

--- a/src/app/signing-profiles/page.tsx
+++ b/src/app/signing-profiles/page.tsx
@@ -182,7 +182,7 @@ export default function SigningProfilesPage() {
   
   const handleConfirmDelete = async () => {
     if (!profileToDelete) {
-      sileo.error({ title: "Error", description: "No profile selected or user not authenticated." });
+      sileo.error({ title: "Error", description: "No profile selected." });
       return;
     }
     

--- a/src/components/home/BackendStatusCheck.tsx
+++ b/src/components/home/BackendStatusCheck.tsx
@@ -5,7 +5,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Loader2, CheckCircle, XCircle, RefreshCw } from "lucide-react";
-import { requireAccessToken } from '@/lib/auth-session';
+import { apiFetch } from '@/lib/api-client';
 import {
   get_KMS_API_BASE_URL,
   get_CA_API_BASE_URL,
@@ -49,12 +49,9 @@ export const BackendStatusCheck: React.FC = () => {
 
         const statusPromises = servicesToCheck().map(async (service): Promise<ServiceStatus> => {
             try {
-                const accessToken = requireAccessToken();
                 const healthCheckUrl = `${service.url.substring(0, service.url.lastIndexOf('/'))}/health`;
                 
-                const response = await fetch(healthCheckUrl, {
-                    headers: { 'Authorization': `Bearer ${accessToken}` },
-                });
+                const response = await apiFetch(healthCheckUrl);
                 
                 if (!response.ok) {
                     throw new Error(`HTTP ${response.status}`);

--- a/src/components/home/InitializationWizard.tsx
+++ b/src/components/home/InitializationWizard.tsx
@@ -115,7 +115,7 @@ export const InitializationWizard: React.FC = () => {
 
     const handleRunTest = async () => {
         if (availableEngines.length === 0) {
-            const errorMsg = "Cannot run test: User not authenticated or no crypto engines available.";
+            const errorMsg = "Cannot run test: no crypto engines available.";
             addLog(errorMsg, 'error');
             setTestError(errorMsg);
             return;

--- a/src/components/ra/AwsIotIntegrationTab.tsx
+++ b/src/components/ra/AwsIotIntegrationTab.tsx
@@ -189,7 +189,7 @@ export const AwsIotIntegrationTab: React.FC<AwsIotIntegrationTabProps> = ({ ra, 
 
   const handleSyncCa = async (isRetry = false) => {
     if (!enrollmentCa) {
-        sileo.error({ title: 'Error', description: 'Enrollment CA not found or user not authenticated.' });
+        sileo.error({ title: 'Error', description: 'Enrollment CA not found.' });
         return;
     }
     setIsSyncing(true);

--- a/src/components/shared/BackendStatusDialog.tsx
+++ b/src/components/shared/BackendStatusDialog.tsx
@@ -6,7 +6,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Loader2, CheckCircle, XCircle, RefreshCw } from "lucide-react";
-import { requireAccessToken } from '@/lib/auth-session';
+import { apiFetch } from '@/lib/api-client';
 import {
   get_KMS_API_BASE_URL,
   get_CA_API_BASE_URL,
@@ -54,12 +54,9 @@ export const BackendStatusDialog: React.FC<BackendStatusDialogProps> = ({ isOpen
 
         const statusPromises = servicesToCheck.map(async (service): Promise<ServiceStatus> => {
             try {
-                const accessToken = requireAccessToken();
                 const healthCheckUrl = `${service.url.substring(0, service.url.lastIndexOf('/'))}/health`;
                 
-                const response = await fetch(healthCheckUrl, {
-                    headers: { 'Authorization': `Bearer ${accessToken}` },
-                });
+                const response = await apiFetch(healthCheckUrl);
                 
                 if (!response.ok) {
                     throw new Error(`HTTP ${response.status} - ${response.statusText}`);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -231,43 +231,42 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   const isLoggedIn = !!user && !user.expired;
 
-  // If auth is disabled, provide the mock context.
-  if (authMode === 'disabled') {
-    const mockUser = new User({
-      id_token: 'mock_id_token',
-      access_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsiYXBwLWFkbWluIiwib2ZmbGluZV9hY2Nlc3MiXX0sIm5hbWUiOiJEZXYgVXNlciJ9.mockSignature',
-      scope: 'openid profile email',
-      token_type: 'Bearer',
-      profile: {
-        sub: 'mock-user-id',
-        name: 'Dev User',
-        email: 'dev@lamassu.io',
-        iss: 'mock-issuer',
-        aud: 'mock-client',
-        exp: Math.floor(Date.now() / 1000) + 3600,
-        iat: Math.floor(Date.now() / 1000),
-      } as UserProfile,
-      expires_at: Math.floor(Date.now() / 1000) + 3600,
-      session_state: 'mock-session-state',
-    });
-
-    const value: AuthContextType = {
-      user: mockUser,
-      isLoading: false,
-      isLoggedIn: true,
-      login: async () => console.warn('Auth disabled: login action suppressed.'),
-      logout: async () => console.warn('Auth disabled: logout action suppressed.'),
-      userManager: null,
-    };
-    return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
-  }
-
-  // If auth is enabled (or still loading), provide the real OIDC context.
-  // Memoized to prevent a new object reference on every render, which would
-  // cause all consumers of this context to re-render unnecessarily.
+  // Keep hook order stable across auth mode changes by always computing the
+  // provider value before deciding what it contains.
   const contextValue = useMemo(
-    () => ({ user, isLoading, isLoggedIn, login, logout, userManager: userManagerInstance }),
-    [user, isLoading, isLoggedIn, login, logout, userManagerInstance]
+    () => {
+      if (authMode === 'disabled') {
+        const mockUser = new User({
+          id_token: 'mock_id_token',
+          access_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsiYXBwLWFkbWluIiwib2ZmbGluZV9hY2Nlc3MiXX0sIm5hbWUiOiJEZXYgVXNlciJ9.mockSignature',
+          scope: 'openid profile email',
+          token_type: 'Bearer',
+          profile: {
+            sub: 'mock-user-id',
+            name: 'Dev User',
+            email: 'dev@lamassu.io',
+            iss: 'mock-issuer',
+            aud: 'mock-client',
+            exp: Math.floor(Date.now() / 1000) + 3600,
+            iat: Math.floor(Date.now() / 1000),
+          } as UserProfile,
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+          session_state: 'mock-session-state',
+        });
+
+        return {
+          user: mockUser,
+          isLoading: false,
+          isLoggedIn: true,
+          login: async () => console.warn('Auth disabled: login action suppressed.'),
+          logout: async () => console.warn('Auth disabled: logout action suppressed.'),
+          userManager: null,
+        };
+      }
+
+      return { user, isLoading, isLoggedIn, login, logout, userManager: userManagerInstance };
+    },
+    [authMode, user, isLoading, isLoggedIn, login, logout, userManagerInstance]
   );
 
   return (

--- a/src/lib/alerts-api.ts
+++ b/src/lib/alerts-api.ts
@@ -3,7 +3,7 @@
 'use client'; // This can be a client-side library function
 
 import { get_ALERTS_API_BASE_URL } from './api-domains';
-import { requireAccessToken } from './auth-session';
+import { apiFetch } from './api-client';
 
 export interface ApiAlertEventData {
     specversion: string;
@@ -64,12 +64,7 @@ export interface SubscriptionPayload {
 
 
 export async function fetchLatestAlerts(): Promise<ApiAlertEvent[]> {
-  const accessToken = requireAccessToken();
-  const response = await fetch(`${get_ALERTS_API_BASE_URL()}/events/latest`, {
-    headers: {
-      'Authorization': `Bearer ${accessToken}`,
-    },
-  });
+  const response = await apiFetch(`${get_ALERTS_API_BASE_URL()}/events/latest`);
 
   if (!response.ok) {
     let errorJson;
@@ -90,12 +85,7 @@ export async function fetchLatestAlerts(): Promise<ApiAlertEvent[]> {
 }
 
 export async function fetchSystemSubscriptions(): Promise<ApiSubscription[]> {
-  const accessToken = requireAccessToken();
-  const response = await fetch(`${get_ALERTS_API_BASE_URL()}/user/_lms_system/subscriptions`, {
-    headers: {
-      'Authorization': `Bearer ${accessToken}`,
-    },
-  });
+  const response = await apiFetch(`${get_ALERTS_API_BASE_URL()}/user/_lms_system/subscriptions`);
 
   if (!response.ok) {
     let errorJson;
@@ -116,12 +106,10 @@ export async function fetchSystemSubscriptions(): Promise<ApiSubscription[]> {
 }
 
 export async function subscribeToAlert(payload: SubscriptionPayload): Promise<void> {
-  const accessToken = requireAccessToken();
-  const response = await fetch(`${get_ALERTS_API_BASE_URL()}/user/_lms_system/subscribe`, {
+  const response = await apiFetch(`${get_ALERTS_API_BASE_URL()}/user/_lms_system/subscribe`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `Bearer ${accessToken}`,
     },
     body: JSON.stringify(payload),
   });
@@ -140,12 +128,10 @@ export async function subscribeToAlert(payload: SubscriptionPayload): Promise<vo
 }
 
 export async function updateSubscription(subscriptionId: string, payload: SubscriptionPayload): Promise<void> {
-  const accessToken = requireAccessToken();
-  const response = await fetch(`${get_ALERTS_API_BASE_URL()}/user/_lms_system/subscriptions/${subscriptionId}`, {
+  const response = await apiFetch(`${get_ALERTS_API_BASE_URL()}/user/_lms_system/subscriptions/${subscriptionId}`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `Bearer ${accessToken}`,
     },
     body: JSON.stringify(payload),
   });
@@ -164,12 +150,8 @@ export async function updateSubscription(subscriptionId: string, payload: Subscr
 }
 
 export async function unsubscribeFromAlert(subscriptionId: string): Promise<void> {
-  const accessToken = requireAccessToken();
-  const response = await fetch(`${get_ALERTS_API_BASE_URL()}/user/_lms_system/unsubscribe/${subscriptionId}`, {
+  const response = await apiFetch(`${get_ALERTS_API_BASE_URL()}/user/_lms_system/unsubscribe/${subscriptionId}`, {
     method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${accessToken}`,
-    },
   });
 
   if (!response.ok) {

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -10,7 +10,7 @@ describe('api-client', () => {
   })
 
   it('includes the Authorization header for required auth when a token is available', () => {
-    const headers = createApiHeaders(undefined, 'required')
+    const headers = createApiHeaders()
 
     expect(headers.get('Authorization')).toBe('Bearer test-access-token')
   })
@@ -22,24 +22,22 @@ describe('api-client', () => {
       LAMASSU_AUTH_ENABLED: false,
     }
 
-    const headers = createApiHeaders({ 'Content-Type': 'application/json' }, 'required')
+    const headers = createApiHeaders({ 'Content-Type': 'application/json' })
 
     expect(headers.get('Content-Type')).toBe('application/json')
     expect(headers.has('Authorization')).toBe(false)
   })
 
-  it('omits the Authorization header for optional auth when no token is available', () => {
+  it('throws for auth-enabled requests when auth is enabled and no token is available', () => {
     window.localStorage.clear()
 
-    const headers = createApiHeaders(undefined, 'optional')
-
-    expect(headers.has('Authorization')).toBe(false)
+    expect(() => createApiHeaders()).toThrow('User not authenticated.')
   })
 
-  it('throws for required auth when auth is enabled and no token is available', () => {
-    window.localStorage.clear()
+  it('omits the Authorization header when auth is disabled for a request', () => {
+    const headers = createApiHeaders(undefined, false)
 
-    expect(() => createApiHeaders(undefined, 'required')).toThrow('User not authenticated.')
+    expect(headers.has('Authorization')).toBe(false)
   })
 
   it('removes an explicitly provided Authorization header when auth resolves to no token', async () => {
@@ -63,5 +61,13 @@ describe('api-client', () => {
     expect(requestHeaders.has('Authorization')).toBe(false)
 
     fetchSpy.mockRestore()
+  })
+
+  it('omits the Authorization header when an explicit null token is provided', () => {
+    window.localStorage.clear()
+
+    const headers = createApiHeaders(undefined, true, null)
+
+    expect(headers.has('Authorization')).toBe(false)
   })
 })

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { apiFetch, createApiHeaders } from './api-client'
+
+describe('api-client', () => {
+  const originalConfig = (window as any).lamassuConfig
+
+  afterEach(() => {
+    (window as any).lamassuConfig = originalConfig
+  })
+
+  it('includes the Authorization header for required auth when a token is available', () => {
+    const headers = createApiHeaders(undefined, 'required')
+
+    expect(headers.get('Authorization')).toBe('Bearer test-access-token')
+  })
+
+  it('omits the Authorization header when auth is disabled', () => {
+    window.localStorage.clear();
+    (window as any).lamassuConfig = {
+      ...originalConfig,
+      LAMASSU_AUTH_ENABLED: false,
+    }
+
+    const headers = createApiHeaders({ 'Content-Type': 'application/json' }, 'required')
+
+    expect(headers.get('Content-Type')).toBe('application/json')
+    expect(headers.has('Authorization')).toBe(false)
+  })
+
+  it('omits the Authorization header for optional auth when no token is available', () => {
+    window.localStorage.clear()
+
+    const headers = createApiHeaders(undefined, 'optional')
+
+    expect(headers.has('Authorization')).toBe(false)
+  })
+
+  it('throws for required auth when auth is enabled and no token is available', () => {
+    window.localStorage.clear()
+
+    expect(() => createApiHeaders(undefined, 'required')).toThrow('User not authenticated.')
+  })
+
+  it('removes an explicitly provided Authorization header when auth resolves to no token', async () => {
+    window.localStorage.clear()
+    ;(window as any).lamassuConfig = {
+      ...originalConfig,
+      LAMASSU_AUTH_ENABLED: false,
+    }
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }))
+
+    await apiFetch('https://example.com/health', {
+      headers: {
+        Authorization: 'Bearer stale-token',
+      },
+    })
+
+    const [, init] = fetchSpy.mock.calls[0]
+    const requestHeaders = new Headers(init?.headers)
+
+    expect(requestHeaders.has('Authorization')).toBe(false)
+
+    fetchSpy.mockRestore()
+  })
+})

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -40,6 +40,12 @@ describe('api-client', () => {
     expect(headers.has('Authorization')).toBe(false)
   })
 
+  it('preserves an explicitly provided Authorization header when auth handling is disabled', () => {
+    const headers = createApiHeaders({ Authorization: 'Bearer manual-token' }, false)
+
+    expect(headers.get('Authorization')).toBe('Bearer manual-token')
+  })
+
   it('removes an explicitly provided Authorization header when auth resolves to no token', async () => {
     window.localStorage.clear()
     ;(window as any).lamassuConfig = {
@@ -61,13 +67,5 @@ describe('api-client', () => {
     expect(requestHeaders.has('Authorization')).toBe(false)
 
     fetchSpy.mockRestore()
-  })
-
-  it('omits the Authorization header when an explicit null token is provided', () => {
-    window.localStorage.clear()
-
-    const headers = createApiHeaders(undefined, true, null)
-
-    expect(headers.has('Authorization')).toBe(false)
   })
 })

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -4,17 +4,9 @@ import { getStoredAccessToken, isAuthEnabled } from './auth-session';
 
 interface ApiFetchOptions extends RequestInit {
   auth?: boolean;
-  accessToken?: string | null;
 }
 
-const resolveAccessTokenForRequest = (
-  auth: boolean,
-  accessTokenOverride?: string | null,
-): string | null => {
-  if (accessTokenOverride !== undefined) {
-    return accessTokenOverride || null;
-  }
-
+const resolveAccessTokenForRequest = (auth: boolean): string | null => {
   if (!auth) {
     return null;
   }
@@ -35,10 +27,14 @@ const resolveAccessTokenForRequest = (
 export const createApiHeaders = (
   headers?: HeadersInit,
   auth = true,
-  accessTokenOverride?: string | null,
 ): Headers => {
   const resolvedHeaders = new Headers(headers);
-  const accessToken = resolveAccessTokenForRequest(auth, accessTokenOverride);
+
+  if (!auth) {
+    return resolvedHeaders;
+  }
+
+  const accessToken = resolveAccessTokenForRequest(auth);
 
   if (accessToken) {
     resolvedHeaders.set('Authorization', `Bearer ${accessToken}`);
@@ -51,9 +47,9 @@ export const createApiHeaders = (
 
 export const apiFetch = async (
   input: RequestInfo | URL,
-  { auth = true, accessToken, headers, ...init }: ApiFetchOptions = {},
+  { auth = true, headers, ...init }: ApiFetchOptions = {},
 ): Promise<Response> =>
   fetch(input, {
     ...init,
-    headers: createApiHeaders(headers, auth, accessToken),
+    headers: createApiHeaders(headers, auth),
   });

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -2,23 +2,21 @@
 
 import { getStoredAccessToken, isAuthEnabled } from './auth-session';
 
-export type ApiFetchAuthMode = 'required' | 'optional' | 'none';
-
 interface ApiFetchOptions extends RequestInit {
-  auth?: ApiFetchAuthMode;
+  auth?: boolean;
   accessToken?: string | null;
 }
 
 const resolveAccessTokenForRequest = (
-  auth: ApiFetchAuthMode,
+  auth: boolean,
   accessTokenOverride?: string | null,
 ): string | null => {
-  if (auth === 'none') {
-    return null;
-  }
-
   if (accessTokenOverride !== undefined) {
     return accessTokenOverride || null;
+  }
+
+  if (!auth) {
+    return null;
   }
 
   if (!isAuthEnabled()) {
@@ -27,7 +25,7 @@ const resolveAccessTokenForRequest = (
 
   const accessToken = getStoredAccessToken();
 
-  if (!accessToken && auth === 'required') {
+  if (!accessToken) {
     throw new Error('User not authenticated.');
   }
 
@@ -36,7 +34,7 @@ const resolveAccessTokenForRequest = (
 
 export const createApiHeaders = (
   headers?: HeadersInit,
-  auth: ApiFetchAuthMode = 'required',
+  auth = true,
   accessTokenOverride?: string | null,
 ): Headers => {
   const resolvedHeaders = new Headers(headers);
@@ -53,7 +51,7 @@ export const createApiHeaders = (
 
 export const apiFetch = async (
   input: RequestInfo | URL,
-  { auth = 'required', accessToken, headers, ...init }: ApiFetchOptions = {},
+  { auth = true, accessToken, headers, ...init }: ApiFetchOptions = {},
 ): Promise<Response> =>
   fetch(input, {
     ...init,

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,0 +1,61 @@
+'use client';
+
+import { getStoredAccessToken, isAuthEnabled } from './auth-session';
+
+export type ApiFetchAuthMode = 'required' | 'optional' | 'none';
+
+interface ApiFetchOptions extends RequestInit {
+  auth?: ApiFetchAuthMode;
+  accessToken?: string | null;
+}
+
+const resolveAccessTokenForRequest = (
+  auth: ApiFetchAuthMode,
+  accessTokenOverride?: string | null,
+): string | null => {
+  if (auth === 'none') {
+    return null;
+  }
+
+  if (accessTokenOverride !== undefined) {
+    return accessTokenOverride || null;
+  }
+
+  if (!isAuthEnabled()) {
+    return null;
+  }
+
+  const accessToken = getStoredAccessToken();
+
+  if (!accessToken && auth === 'required') {
+    throw new Error('User not authenticated.');
+  }
+
+  return accessToken;
+};
+
+export const createApiHeaders = (
+  headers?: HeadersInit,
+  auth: ApiFetchAuthMode = 'required',
+  accessTokenOverride?: string | null,
+): Headers => {
+  const resolvedHeaders = new Headers(headers);
+  const accessToken = resolveAccessTokenForRequest(auth, accessTokenOverride);
+
+  if (accessToken) {
+    resolvedHeaders.set('Authorization', `Bearer ${accessToken}`);
+  } else {
+    resolvedHeaders.delete('Authorization');
+  }
+
+  return resolvedHeaders;
+};
+
+export const apiFetch = async (
+  input: RequestInfo | URL,
+  { auth = 'required', accessToken, headers, ...init }: ApiFetchOptions = {},
+): Promise<Response> =>
+  fetch(input, {
+    ...init,
+    headers: createApiHeaders(headers, auth, accessToken),
+  });

--- a/src/lib/auth-session.test.ts
+++ b/src/lib/auth-session.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { requireAccessToken } from './auth-session'
+import { getStoredAccessToken, isAuthEnabled } from './auth-session'
 
 describe('auth-session', () => {
   const originalConfig = (window as any).lamassuConfig
@@ -9,23 +9,28 @@ describe('auth-session', () => {
     (window as any).lamassuConfig = originalConfig
   })
 
-  it('returns the stored access token when authentication is enabled', () => {
-    expect(requireAccessToken()).toBe('test-access-token')
+  it('treats authentication as enabled by default', () => {
+    expect(isAuthEnabled()).toBe(true)
   })
 
-  it('throws when authentication is enabled and no token is stored', () => {
+  it('returns the stored access token when authentication is enabled', () => {
+    expect(getStoredAccessToken()).toBe('test-access-token')
+  })
+
+  it('returns null when authentication is enabled and no token is stored', () => {
     window.localStorage.clear()
 
-    expect(() => requireAccessToken()).toThrow('User not authenticated.')
+    expect(getStoredAccessToken()).toBeNull()
   })
 
-  it('still throws when authentication is disabled and no token is stored', () => {
+  it('reports authentication as disabled when configured off', () => {
     window.localStorage.clear();
     (window as any).lamassuConfig = {
       ...originalConfig,
       LAMASSU_AUTH_ENABLED: false,
     }
 
-    expect(() => requireAccessToken()).toThrow('User not authenticated.')
+    expect(isAuthEnabled()).toBe(false)
+    expect(getStoredAccessToken()).toBeNull()
   })
 })

--- a/src/lib/auth-session.test.ts
+++ b/src/lib/auth-session.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { requireAccessToken } from './auth-session'
+
+describe('auth-session', () => {
+  const originalConfig = (window as any).lamassuConfig
+
+  afterEach(() => {
+    (window as any).lamassuConfig = originalConfig
+  })
+
+  it('returns the stored access token when authentication is enabled', () => {
+    expect(requireAccessToken()).toBe('test-access-token')
+  })
+
+  it('throws when authentication is enabled and no token is stored', () => {
+    window.localStorage.clear()
+
+    expect(() => requireAccessToken()).toThrow('User not authenticated.')
+  })
+
+  it('does not throw when authentication is disabled and no token is stored', () => {
+    window.localStorage.clear();
+    (window as any).lamassuConfig = {
+      ...originalConfig,
+      LAMASSU_AUTH_ENABLED: false,
+    }
+
+    expect(requireAccessToken()).toBe('')
+  })
+})

--- a/src/lib/auth-session.test.ts
+++ b/src/lib/auth-session.test.ts
@@ -19,13 +19,13 @@ describe('auth-session', () => {
     expect(() => requireAccessToken()).toThrow('User not authenticated.')
   })
 
-  it('does not throw when authentication is disabled and no token is stored', () => {
+  it('still throws when authentication is disabled and no token is stored', () => {
     window.localStorage.clear();
     (window as any).lamassuConfig = {
       ...originalConfig,
       LAMASSU_AUTH_ENABLED: false,
     }
 
-    expect(requireAccessToken()).toBe('')
+    expect(() => requireAccessToken()).toThrow('User not authenticated.')
   })
 })

--- a/src/lib/auth-session.ts
+++ b/src/lib/auth-session.ts
@@ -1,5 +1,13 @@
 'use client';
 
+const isAuthDisabled = (): boolean => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return (window as any).lamassuConfig?.LAMASSU_AUTH_ENABLED === false;
+};
+
 export const getStoredAccessToken = (): string | null => {
   if (typeof window === 'undefined') {
     return null;
@@ -27,6 +35,10 @@ export const getStoredAccessToken = (): string | null => {
 
 export const requireAccessToken = (): string => {
   const resolvedAccessToken = getStoredAccessToken();
+
+  if (!resolvedAccessToken && isAuthDisabled()) {
+    return '';
+  }
 
   if (!resolvedAccessToken) {
     throw new Error('User not authenticated.');

--- a/src/lib/auth-session.ts
+++ b/src/lib/auth-session.ts
@@ -32,13 +32,3 @@ export const getStoredAccessToken = (): string | null => {
     return null;
   }
 };
-
-export const requireAccessToken = (): string => {
-  const resolvedAccessToken = getStoredAccessToken();
-
-  if (!resolvedAccessToken) {
-    throw new Error('User not authenticated.');
-  }
-
-  return resolvedAccessToken;
-};

--- a/src/lib/auth-session.ts
+++ b/src/lib/auth-session.ts
@@ -1,11 +1,11 @@
 'use client';
 
-const isAuthDisabled = (): boolean => {
+export const isAuthEnabled = (): boolean => {
   if (typeof window === 'undefined') {
-    return false;
+    return true;
   }
 
-  return (window as any).lamassuConfig?.LAMASSU_AUTH_ENABLED === false;
+  return (window as any).lamassuConfig?.LAMASSU_AUTH_ENABLED !== false;
 };
 
 export const getStoredAccessToken = (): string | null => {
@@ -35,10 +35,6 @@ export const getStoredAccessToken = (): string | null => {
 
 export const requireAccessToken = (): string => {
   const resolvedAccessToken = getStoredAccessToken();
-
-  if (!resolvedAccessToken && isAuthDisabled()) {
-    return '';
-  }
 
   if (!resolvedAccessToken) {
     throw new Error('User not authenticated.');

--- a/src/lib/ca-data.ts
+++ b/src/lib/ca-data.ts
@@ -3,7 +3,7 @@
 // Define the CA data structure
 import { parseCertificatePemDetails, type ParsedPemDetails, abToHex } from "@/lib-crypto";
 import { get_CA_API_BASE_URL, get_DEV_MANAGER_API_BASE_URL, handleApiError } from "./api-domains";
-import { requireAccessToken } from "./auth-session";
+import { apiFetch } from "./api-client";
 
 // API Response Structures
 interface ApiKeyMetadata {
@@ -222,7 +222,6 @@ function buildCaHierarchy(flatCaList: Omit<CA, 'children'>[]): CA[] {
 
 // Function to fetch, transform, and build hierarchy
 export async function fetchAndProcessCAs(apiQueryString?: string): Promise<CA[]> {
-    const accessToken = requireAccessToken();
     let allCAs: ApiCaItem[] = [];
     let nextBookmark: string | null = null;
     let hasNextPage = true;
@@ -245,9 +244,7 @@ export async function fetchAndProcessCAs(apiQueryString?: string): Promise<CA[]>
             url.searchParams.set('bookmark', nextBookmark);
         }
 
-        const response = await fetch(url.toString(), {
-            headers: { 'Authorization': `Bearer ${accessToken}` },
-        });
+        const response = await apiFetch(url.toString());
 
         if (!response.ok) {
             let errorJson;
@@ -338,12 +335,10 @@ export interface CreateCaPayload {
 }
 
 export async function createCa(payload: CreateCaPayload): Promise<void> {
-  const accessToken = requireAccessToken();
-  const response = await fetch(`${get_CA_API_BASE_URL()}/cas`, {
+  const response = await apiFetch(`${get_CA_API_BASE_URL()}/cas`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `Bearer ${accessToken}`,
     },
     body: JSON.stringify(payload),
   });
@@ -374,12 +369,10 @@ export interface ImportCaPayload {
 }
 
 export async function importCa(payload: ImportCaPayload): Promise<void> {
-  const accessToken = requireAccessToken();
-  const response = await fetch(`${get_CA_API_BASE_URL()}/cas/import`, {
+  const response = await apiFetch(`${get_CA_API_BASE_URL()}/cas/import`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `Bearer ${accessToken}`,
     },
     body: JSON.stringify(payload),
   });
@@ -404,12 +397,10 @@ export interface PatchOperation {
 }
 
 export async function updateCaMetadata(caId: string, patchOperations: PatchOperation[]): Promise<void> {
-  const accessToken = requireAccessToken();
-  const response = await fetch(`${get_CA_API_BASE_URL()}/cas/${caId}/metadata`, {
+  const response = await apiFetch(`${get_CA_API_BASE_URL()}/cas/${caId}/metadata`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `Bearer ${accessToken}`,
     },
     body: JSON.stringify({ patches: patchOperations }),
   });
@@ -432,10 +423,7 @@ interface CaStats {
   REVOKED: number;
 }
 export async function fetchCaStats(caId: string): Promise<CaStats> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_CA_API_BASE_URL()}/stats/${caId}`, {
-        headers: { 'Authorization': `Bearer ${accessToken}` },
-    });
+    const response = await apiFetch(`${get_CA_API_BASE_URL()}/stats/${caId}`);
     if (!response.ok) {
         let errorBody = 'Request failed.';
         try {
@@ -450,16 +438,14 @@ export async function fetchCaStats(caId: string): Promise<CaStats> {
 }
 
 export async function updateCaStatus(caId: string, status: 'ACTIVE' | 'REVOKED', reason?: string): Promise<void> {
-    const accessToken = requireAccessToken();
     const body: { status: string; revocation_reason?: string } = { status };
     if (status === 'REVOKED' && reason) {
         body.revocation_reason = reason;
     }
-    const response = await fetch(`${get_CA_API_BASE_URL()}/cas/${caId}/status`, {
+    const response = await apiFetch(`${get_CA_API_BASE_URL()}/cas/${caId}/status`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${accessToken}`,
         },
         body: JSON.stringify(body),
     });
@@ -477,12 +463,10 @@ export async function updateCaStatus(caId: string, status: 'ACTIVE' | 'REVOKED',
 }
 
 export async function revokeCa(caId: string, reason: string): Promise<void> {
-  const accessToken = requireAccessToken();
-  const response = await fetch(`${get_CA_API_BASE_URL()}/cas/${caId}/status`, {
+  const response = await apiFetch(`${get_CA_API_BASE_URL()}/cas/${caId}/status`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `Bearer ${accessToken}`,
     },
     body: JSON.stringify({ status: 'REVOKED', revocation_reason: reason }),
   });
@@ -502,10 +486,8 @@ export async function revokeCa(caId: string, reason: string): Promise<void> {
 
 
 export async function deleteCa(caId: string): Promise<void> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_CA_API_BASE_URL()}/cas/${caId}`, {
+    const response = await apiFetch(`${get_CA_API_BASE_URL()}/cas/${caId}`, {
         method: 'DELETE',
-        headers: { 'Authorization': `Bearer ${accessToken}` },
     });
 
     if (!response.ok) {
@@ -527,12 +509,10 @@ export interface ReissueCAPayload {
 }
 
 export async function reissueCa(caId: string, payload: ReissueCAPayload): Promise<ApiCaItem> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_CA_API_BASE_URL()}/cas/${caId}/reissue`, {
+    const response = await apiFetch(`${get_CA_API_BASE_URL()}/cas/${caId}/reissue`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${accessToken}`,
         },
         body: JSON.stringify(payload),
     });
@@ -553,10 +533,9 @@ export async function reissueCa(caId: string, payload: ReissueCAPayload): Promis
 }
 
 export async function signCertificate(caId: string, payload: any): Promise<any> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_CA_API_BASE_URL()}/cas/${caId}/certificates/sign`, {
+    const response = await apiFetch(`${get_CA_API_BASE_URL()}/cas/${caId}/certificates/sign`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${accessToken}` },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
     });
     const result = await response.json();
@@ -567,12 +546,10 @@ export async function signCertificate(caId: string, payload: any): Promise<any> 
 }
 
 export async function updateCaDefaultProfileId(caId: string, profileId: string | null): Promise<void> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_CA_API_BASE_URL()}/cas/${caId}/profile`, {
+    const response = await apiFetch(`${get_CA_API_BASE_URL()}/cas/${caId}/profile`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${accessToken}`
         },
         body: JSON.stringify({ profile_id: profileId })
     });
@@ -596,18 +573,12 @@ export interface CaStatsSummaryResponse {
 }
 
 export async function fetchCaStatsSummary(): Promise<CaStatsSummaryResponse> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_CA_API_BASE_URL()}/stats`, {
-        headers: { 'Authorization': `Bearer ${accessToken}` },
-    });
+    const response = await apiFetch(`${get_CA_API_BASE_URL()}/stats`);
     return handleApiError(response, 'Failed to fetch CA stats');
 }
 
 export async function fetchDevManagerStats(): Promise<{ total: number }> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_DEV_MANAGER_API_BASE_URL()}/stats`, { 
-        headers: { 'Authorization': `Bearer ${accessToken}` } 
-    });
+    const response = await apiFetch(`${get_DEV_MANAGER_API_BASE_URL()}/stats`);
     return handleApiError(response, 'Failed to fetch Device stats');
 }
 
@@ -651,15 +622,12 @@ export interface ApiSigningProfileListResponse {
 }
 
 export async function fetchSigningProfiles(params?: URLSearchParams): Promise<ApiSigningProfileListResponse> {
-    const accessToken = requireAccessToken();
     const url = new URL(`${get_CA_API_BASE_URL()}/profiles`);
     if (params) {
         params.forEach((value, key) => url.searchParams.append(key, value));
     }
     
-    const response = await fetch(url.toString(), {
-        headers: { 'Authorization': `Bearer ${accessToken}` },
-    });
+    const response = await apiFetch(url.toString());
     
     return handleApiError(response, 'Failed to fetch signing profiles');
 }
@@ -697,12 +665,10 @@ export interface CreateSigningProfilePayload {
 }
 
 export async function createSigningProfile(payload: CreateSigningProfilePayload): Promise<ApiSigningProfile> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_CA_API_BASE_URL()}/profiles`, {
+    const response = await apiFetch(`${get_CA_API_BASE_URL()}/profiles`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${accessToken}`
         },
         body: JSON.stringify(payload)
     });
@@ -721,10 +687,7 @@ export async function createSigningProfile(payload: CreateSigningProfilePayload)
 }
 
 export async function fetchSigningProfileById(profileId: string): Promise<ApiSigningProfile> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_CA_API_BASE_URL()}/profiles/${profileId}`, {
-        headers: { 'Authorization': `Bearer ${accessToken}` },
-    });
+    const response = await apiFetch(`${get_CA_API_BASE_URL()}/profiles/${profileId}`);
     if (!response.ok) {
         let errorJson;
         let errorMessage = `Failed to fetch signing profile. HTTP error ${response.status}`;
@@ -740,12 +703,10 @@ export async function fetchSigningProfileById(profileId: string): Promise<ApiSig
 }
 
 export async function updateSigningProfile(profileId: string, payload: CreateSigningProfilePayload): Promise<void> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_CA_API_BASE_URL()}/profiles/${profileId}`, {
+    const response = await apiFetch(`${get_CA_API_BASE_URL()}/profiles/${profileId}`, {
         method: 'PUT',
         headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${accessToken}`
         },
         body: JSON.stringify(payload)
     });
@@ -763,12 +724,8 @@ export async function updateSigningProfile(profileId: string, payload: CreateSig
 }
 
 export async function deleteSigningProfile(profileId: string): Promise<void> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_CA_API_BASE_URL()}/profiles/${profileId}`, {
+    const response = await apiFetch(`${get_CA_API_BASE_URL()}/profiles/${profileId}`, {
         method: 'DELETE',
-        headers: {
-            'Authorization': `Bearer ${accessToken}`
-        },
     });
     if (!response.ok) {
         let errorJson;
@@ -841,12 +798,12 @@ export interface CreateCertificatePayload {
 }
 
 export async function createCertificate(payload: CreateCertificatePayload, accessToken: string): Promise<any> {
-    const response = await fetch(`${get_CA_API_BASE_URL()}/certificates`, {
+    const response = await apiFetch(`${get_CA_API_BASE_URL()}/certificates`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${accessToken}`,
         },
+        accessToken,
         body: JSON.stringify(payload),
     });
     if (!response.ok) {

--- a/src/lib/ca-data.ts
+++ b/src/lib/ca-data.ts
@@ -802,8 +802,9 @@ export async function createCertificate(payload: CreateCertificatePayload, acces
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
+            'Authorization': `Bearer ${accessToken}`,
         },
-        accessToken,
+        auth: false,
         body: JSON.stringify(payload),
     });
     if (!response.ok) {

--- a/src/lib/device-groups-api.ts
+++ b/src/lib/device-groups-api.ts
@@ -1,5 +1,5 @@
 import { get_DEV_MANAGER_API_BASE_URL, handleApiError } from './api-domains';
-import { requireAccessToken } from './auth-session';
+import { apiFetch } from './api-client';
 import type {
   DeviceGroup,
   CreateDeviceGroupBody,
@@ -21,7 +21,6 @@ export async function getDeviceGroups(
     filter?: string;
   }
 ): Promise<GetDeviceGroupsResponse> {
-  const accessToken = requireAccessToken();
   const queryParams = new URLSearchParams();
   
   if (params?.pageSize) queryParams.append('limit', params.pageSize.toString());
@@ -30,12 +29,11 @@ export async function getDeviceGroups(
   if (params?.sortMode) queryParams.append('sort_mode', params.sortMode);
   if (params?.filter) queryParams.append('filter', params.filter);
 
-  const response = await fetch(
+  const response = await apiFetch(
     `${get_DEV_MANAGER_API_BASE_URL()}/device-groups?${queryParams.toString()}`,
     {
       method: 'GET',
       headers: {
-        'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
       },
     }
@@ -50,13 +48,11 @@ export async function getDeviceGroups(
 export async function getDeviceGroupByID(
   id: string
 ): Promise<DeviceGroup> {
-  const accessToken = requireAccessToken();
-  const response = await fetch(
+  const response = await apiFetch(
     `${get_DEV_MANAGER_API_BASE_URL()}/device-groups/${id}`,
     {
       method: 'GET',
       headers: {
-        'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
       },
     }
@@ -71,13 +67,11 @@ export async function getDeviceGroupByID(
 export async function createDeviceGroup(
   body: CreateDeviceGroupBody
 ): Promise<DeviceGroup> {
-  const accessToken = requireAccessToken();
-  const response = await fetch(
+  const response = await apiFetch(
     `${get_DEV_MANAGER_API_BASE_URL()}/device-groups`,
     {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(body),
@@ -94,13 +88,11 @@ export async function updateDeviceGroup(
   id: string,
   body: UpdateDeviceGroupBody
 ): Promise<DeviceGroup> {
-  const accessToken = requireAccessToken();
-  const response = await fetch(
+  const response = await apiFetch(
     `${get_DEV_MANAGER_API_BASE_URL()}/device-groups/${id}`,
     {
       method: 'PUT',
       headers: {
-        'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(body),
@@ -116,14 +108,10 @@ export async function updateDeviceGroup(
 export async function deleteDeviceGroup(
   id: string
 ): Promise<void> {
-  const accessToken = requireAccessToken();
-  const response = await fetch(
+  const response = await apiFetch(
     `${get_DEV_MANAGER_API_BASE_URL()}/device-groups/${id}`,
     {
       method: 'DELETE',
-      headers: {
-        'Authorization': `Bearer ${accessToken}`,
-      },
     }
   );
 
@@ -145,7 +133,6 @@ export async function getDevicesByGroup(
     filters?: string[];
   }
 ): Promise<GetDevicesByGroupResponse> {
-  const accessToken = requireAccessToken();
   const queryParams = new URLSearchParams();
   
   if (params?.pageSize) queryParams.append('limit', params.pageSize.toString());
@@ -156,12 +143,11 @@ export async function getDevicesByGroup(
     params.filters.forEach(filter => queryParams.append('filter', filter));
   }
 
-  const response = await fetch(
+  const response = await apiFetch(
     `${get_DEV_MANAGER_API_BASE_URL()}/device-groups/${groupId}/devices?${queryParams.toString()}`,
     {
       method: 'GET',
       headers: {
-        'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
       },
     }
@@ -176,13 +162,11 @@ export async function getDevicesByGroup(
 export async function getDeviceGroupStats(
   groupId: string
 ): Promise<DeviceGroupStats> {
-  const accessToken = requireAccessToken();
-  const response = await fetch(
+  const response = await apiFetch(
     `${get_DEV_MANAGER_API_BASE_URL()}/device-groups/${groupId}/stats`,
     {
       method: 'GET',
       headers: {
-        'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
       },
     }

--- a/src/lib/devices-api.ts
+++ b/src/lib/devices-api.ts
@@ -1,7 +1,7 @@
 
 // src/lib/devices-api.ts
 import { get_DEV_MANAGER_API_BASE_URL, handleApiError } from './api-domains';
-import { requireAccessToken } from './auth-session';
+import { apiFetch } from './api-client';
 
 // Interfaces based on usage in components
 export interface ApiDeviceIdentity {
@@ -53,29 +53,21 @@ export interface PatchOperation {
 
 
 export async function fetchDevices(params: URLSearchParams): Promise<ApiResponse> {
-    const accessToken = requireAccessToken();
     const url = `${get_DEV_MANAGER_API_BASE_URL()}/devices?${params.toString()}`;
-    const response = await fetch(url, {
-        headers: { 'Authorization': `Bearer ${accessToken}` },
-    });
+    const response = await apiFetch(url);
     return handleApiError(response, 'Failed to fetch devices');
 }
 
 export async function fetchDeviceById(deviceId: string): Promise<ApiDevice> {
-    const accessToken = requireAccessToken();
     const url = `${get_DEV_MANAGER_API_BASE_URL()}/devices/${deviceId}`;
-    const response = await fetch(url, {
-        headers: { 'Authorization': `Bearer ${accessToken}` },
-    });
+    const response = await apiFetch(url);
     return handleApiError(response, 'Failed to fetch device details');
 }
 
 export async function decommissionDevice(deviceId: string): Promise<void> {
-    const accessToken = requireAccessToken();
     const url = `${get_DEV_MANAGER_API_BASE_URL()}/devices/${deviceId}/decommission`;
-    const response = await fetch(url, {
+    const response = await apiFetch(url, {
         method: 'DELETE',
-        headers: { 'Authorization': `Bearer ${accessToken}` },
     });
     if (!response.ok) {
         await handleApiError(response, 'Failed to decommission device');
@@ -83,13 +75,11 @@ export async function decommissionDevice(deviceId: string): Promise<void> {
 }
 
 export async function registerDevice(payload: any): Promise<void> {
-    const accessToken = requireAccessToken();
     const url = `${get_DEV_MANAGER_API_BASE_URL()}/devices`;
-    const response = await fetch(url, {
+    const response = await apiFetch(url, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${accessToken}`,
         },
         body: JSON.stringify(payload),
     });
@@ -99,20 +89,15 @@ export async function registerDevice(payload: any): Promise<void> {
 }
 
 export async function fetchDeviceStats(): Promise<DeviceStats> {
-  const accessToken = requireAccessToken();
-  const response = await fetch(`${get_DEV_MANAGER_API_BASE_URL()}/stats`, {
-    headers: { 'Authorization': `Bearer ${accessToken}` },
-  });
+  const response = await apiFetch(`${get_DEV_MANAGER_API_BASE_URL()}/stats`);
   return handleApiError(response, 'Failed to fetch device stats');
 }
 
 export async function updateDeviceMetadata(deviceId: string, patchOperations: PatchOperation[]): Promise<void> {
-  const accessToken = requireAccessToken();
-  const response = await fetch(`${get_DEV_MANAGER_API_BASE_URL()}/devices/${deviceId}/metadata`, {
+  const response = await apiFetch(`${get_DEV_MANAGER_API_BASE_URL()}/devices/${deviceId}/metadata`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `Bearer ${accessToken}`,
     },
     body: JSON.stringify({ patches: patchOperations }),
   });
@@ -123,11 +108,9 @@ export async function updateDeviceMetadata(deviceId: string, patchOperations: Pa
 }
 
 export async function deleteDevice(deviceId: string): Promise<void> {
-    const accessToken = requireAccessToken();
     const url = `${get_DEV_MANAGER_API_BASE_URL()}/devices/${deviceId}`;
-    const response = await fetch(url, {
+    const response = await apiFetch(url, {
         method: 'DELETE',
-        headers: { 'Authorization': `Bearer ${accessToken}` },
     });
     if (!response.ok) {
         await handleApiError(response, 'Failed to delete device');

--- a/src/lib/dms-api.ts
+++ b/src/lib/dms-api.ts
@@ -2,7 +2,7 @@
 // src/lib/dms-api.ts
 
 import { get_DMS_MANAGER_API_BASE_URL, handleApiError } from './api-domains';
-import { requireAccessToken } from './auth-session';
+import { apiFetch } from './api-client';
 
 // --- Interfaces ---
 
@@ -87,7 +87,6 @@ export interface RaCreationPayload {
 // --- API Functions ---
 
 export async function fetchRegistrationAuthorities(params?: URLSearchParams): Promise<ApiRaListResponse> {
-    const accessToken = requireAccessToken();
     const url = new URL(`${get_DMS_MANAGER_API_BASE_URL()}/dms`);
     if (params) {
         params.forEach((value, key) => url.searchParams.append(key, value));
@@ -96,9 +95,7 @@ export async function fetchRegistrationAuthorities(params?: URLSearchParams): Pr
         url.searchParams.set('page_size', '9');
     }
     
-    const response = await fetch(url.toString(), {
-        headers: { 'Authorization': `Bearer ${accessToken}` },
-    });
+    const response = await apiFetch(url.toString());
     return handleApiError(response, 'Failed to fetch RAs');
 }
 
@@ -127,10 +124,7 @@ export async function fetchAllRegistrationAuthorities(): Promise<ApiRaItem[]> {
 }
 
 export async function fetchRaById(raId: string): Promise<ApiRaItem> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_DMS_MANAGER_API_BASE_URL()}/dms/${raId}`, {
-        headers: { 'Authorization': `Bearer ${accessToken}` },
-    });
+    const response = await apiFetch(`${get_DMS_MANAGER_API_BASE_URL()}/dms/${raId}`);
     return handleApiError(response, 'Failed to fetch RA details');
 }
 
@@ -139,15 +133,14 @@ export async function createOrUpdateRa(
     isEditMode: boolean,
     raId?: string | null,
 ): Promise<void> {
-    const accessToken = requireAccessToken();
     const url = isEditMode
         ? `${get_DMS_MANAGER_API_BASE_URL()}/dms/${raId}`
         : `${get_DMS_MANAGER_API_BASE_URL()}/dms`;
     const method = isEditMode ? 'PUT' : 'POST';
 
-    const response = await fetch(url, {
+    const response = await apiFetch(url, {
         method: method,
-        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${accessToken}` },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
     });
 
@@ -167,12 +160,10 @@ export async function createOrUpdateRa(
 
 
 export async function bindIdentityToDevice(deviceId: string, certificateSerialNumber: string): Promise<void> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_DMS_MANAGER_API_BASE_URL()}/dms/bind-identity`, {
+    const response = await apiFetch(`${get_DMS_MANAGER_API_BASE_URL()}/dms/bind-identity`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${accessToken}`
         },
         body: JSON.stringify({
             device_id: deviceId,
@@ -186,10 +177,7 @@ export async function bindIdentityToDevice(deviceId: string, certificateSerialNu
 
 
 export async function fetchDmsStats(): Promise<{ total: number }> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_DMS_MANAGER_API_BASE_URL()}/stats`, { 
-        headers: { 'Authorization': `Bearer ${accessToken}` } 
-    });
+    const response = await apiFetch(`${get_DMS_MANAGER_API_BASE_URL()}/stats`);
     return handleApiError(response, 'Failed to fetch RA stats');
 }
 
@@ -233,11 +221,9 @@ export async function deleteRaIntegration(raId: string, integrationKey: string):
 }
 
 export async function deleteRa(raId: string): Promise<void> {
-    const accessToken = requireAccessToken();
     const url = `${get_DMS_MANAGER_API_BASE_URL()}/dms/${raId}`;
-    const response = await fetch(url, {
+    const response = await apiFetch(url, {
         method: 'DELETE',
-        headers: { 'Authorization': `Bearer ${accessToken}` },
     });
     if (!response.ok) {
         await handleApiError(response, 'Failed to delete RA');

--- a/src/lib/est-api.ts
+++ b/src/lib/est-api.ts
@@ -2,6 +2,7 @@
 
 import { get_EST_API_BASE_URL } from './api-domains';
 import { apiFetch } from './api-client';
+import { getStoredAccessToken } from './auth-session';
 
 /**
  * Fetches CA certificates from the EST endpoint for a given RA.
@@ -19,7 +20,7 @@ export async function fetchEstCaCerts(
         'Accept': `application/${format}`,
     };
 
-    const response = await apiFetch(url, { auth: 'optional', headers });
+    const response = await apiFetch(url, { headers });
 
     if (!response.ok) {
         // Can't use handleApiError because it expects JSON, and this endpoint might not return it on error.
@@ -33,7 +34,7 @@ export async function fetchEstCaCerts(
         }
         throw new Error(errorMessage);
     }
-    
+
     const contentType = response.headers.get('content-type') || `application/${format}`;
 
     if (format === 'pkcs7-mime') {

--- a/src/lib/est-api.ts
+++ b/src/lib/est-api.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { get_EST_API_BASE_URL } from './api-domains';
-import { getStoredAccessToken } from './auth-session';
+import { apiFetch } from './api-client';
 
 /**
  * Fetches CA certificates from the EST endpoint for a given RA.
@@ -18,12 +18,8 @@ export async function fetchEstCaCerts(
     const headers: HeadersInit = {
         'Accept': `application/${format}`,
     };
-    const accessToken = getStoredAccessToken();
-    if (accessToken) {
-        headers['Authorization'] = `Bearer ${accessToken}`;
-    }
 
-    const response = await fetch(url, { headers });
+    const response = await apiFetch(url, { auth: 'optional', headers });
 
     if (!response.ok) {
         // Can't use handleApiError because it expects JSON, and this endpoint might not return it on error.

--- a/src/lib/est-api.ts
+++ b/src/lib/est-api.ts
@@ -19,8 +19,13 @@ export async function fetchEstCaCerts(
     const headers: HeadersInit = {
         'Accept': `application/${format}`,
     };
+    const accessToken = getStoredAccessToken();
 
-    const response = await apiFetch(url, { headers });
+    if (accessToken) {
+        headers['Authorization'] = `Bearer ${accessToken}`;
+    }
+
+    const response = await apiFetch(url, { auth: false, headers });
 
     if (!response.ok) {
         // Can't use handleApiError because it expects JSON, and this endpoint might not return it on error.

--- a/src/lib/issued-certificate-data.ts
+++ b/src/lib/issued-certificate-data.ts
@@ -1,7 +1,7 @@
 
 import type { CertificateData } from '@/types/certificate';
 import { get_CA_API_BASE_URL } from './api-domains';
-import { requireAccessToken } from './auth-session';
+import { apiFetch } from './api-client';
 import { parseCertificatePemDetails } from './ca-data';
 
 
@@ -120,11 +120,8 @@ async function transformApiIssuedCertificateToLocal(apiCert: ApiIssuedCertificat
 }
 
 export async function fetchIssuedCertificate(serialNumber: string): Promise<CertificateData> {
-  const accessToken = requireAccessToken();
   const apiSerial = serialNumber.replace(/:/g, '');
-  const response = await fetch(`${get_CA_API_BASE_URL()}/certificates/${encodeURIComponent(apiSerial)}`, {
-    headers: { 'Authorization': `Bearer ${accessToken}` },
-  });
+  const response = await apiFetch(`${get_CA_API_BASE_URL()}/certificates/${encodeURIComponent(apiSerial)}`);
   if (!response.ok) {
     let errorMessage = `Failed to fetch certificate. HTTP error ${response.status}`;
     try {
@@ -146,7 +143,6 @@ interface FetchIssuedCertificatesParams {
 export async function fetchIssuedCertificates(
   params: FetchIssuedCertificatesParams
 ): Promise<{ certificates: CertificateData[]; nextToken: string | null }> {
-  const accessToken = requireAccessToken();
   const { apiQueryString, forCaId } = params;
 
   const baseUrl = forCaId
@@ -155,11 +151,7 @@ export async function fetchIssuedCertificates(
 
   const finalQueryString = apiQueryString || 'sort_by=valid_from&sort_mode=desc&page_size=10';
 
-  const response = await fetch(`${baseUrl}?${finalQueryString}`, {
-    headers: {
-      'Authorization': `Bearer ${accessToken}`,
-    },
-  });
+  const response = await apiFetch(`${baseUrl}?${finalQueryString}`);
 
   if (!response.ok) {
     let errorJson;
@@ -206,7 +198,6 @@ export async function updateCertificateStatus({
   status,
   reason,
 }: UpdateStatusParams): Promise<void> {
-  const accessToken = requireAccessToken();
   const body: { status: 'ACTIVE' | 'REVOKED', revocation_reason?: string } = { status };
   if (status === 'REVOKED' && reason) {
     body.revocation_reason = reason;
@@ -214,11 +205,10 @@ export async function updateCertificateStatus({
 
   const apiFormattedSerialNumber = serialNumber.replace(/:/g, '');
 
-  const response = await fetch(`${get_CA_API_BASE_URL()}/certificates/${apiFormattedSerialNumber}/status`, {
+  const response = await apiFetch(`${get_CA_API_BASE_URL()}/certificates/${apiFormattedSerialNumber}/status`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `Bearer ${accessToken}`,
     },
     body: JSON.stringify(body),
   });
@@ -244,13 +234,11 @@ export interface PatchOperation {
 }
 
 export async function updateCertificateMetadata(serialNumber: string, patchOperations: PatchOperation[]): Promise<void> {
-  const accessToken = requireAccessToken();
   const apiFormattedSerialNumber = serialNumber.replace(/:/g, '');
-  const response = await fetch(`${get_CA_API_BASE_URL()}/certificates/${apiFormattedSerialNumber}/metadata`, {
+  const response = await apiFetch(`${get_CA_API_BASE_URL()}/certificates/${apiFormattedSerialNumber}/metadata`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `Bearer ${accessToken}`,
     },
     body: JSON.stringify({ patches: patchOperations }),
   });
@@ -275,12 +263,10 @@ export interface ImportCertificateBody {
 }
 
 export async function importCertificate(payload: ImportCertificateBody): Promise<void> {
-  const accessToken = requireAccessToken();
-  const response = await fetch(`${get_CA_API_BASE_URL()}/certificates/import`, {
+  const response = await apiFetch(`${get_CA_API_BASE_URL()}/certificates/import`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `Bearer ${accessToken}`,
     },
     body: JSON.stringify(payload),
   });
@@ -298,13 +284,9 @@ export async function importCertificate(payload: ImportCertificateBody): Promise
 }
 
 export async function deleteCertificate(serialNumber: string): Promise<void> {
-    const accessToken = requireAccessToken();
     const apiFormattedSerialNumber = serialNumber.replace(/:/g, '');
-    const response = await fetch(`${get_CA_API_BASE_URL()}/certificates/${apiFormattedSerialNumber}`, {
+    const response = await apiFetch(`${get_CA_API_BASE_URL()}/certificates/${apiFormattedSerialNumber}`, {
         method: 'DELETE',
-        headers: {
-            'Authorization': `Bearer ${accessToken}`,
-        },
     });
 
   if (!response.ok) {

--- a/src/lib/kms-data.ts
+++ b/src/lib/kms-data.ts
@@ -1,7 +1,7 @@
 // KMS (Key Management Service) API functions
 import { ApiCryptoEngine } from "@/types/crypto-engine";
 import { get_KMS_API_BASE_URL } from "./api-domains";
-import { requireAccessToken } from "./auth-session";
+import { apiFetch } from "./api-client";
 
 // --- KMS Key Types and Interfaces ---
 
@@ -45,10 +45,7 @@ export interface ImportKmsKeyPayload {
 
 // --- KMS Key API Functions ---
 export async function fetchCryptoEngines(): Promise<ApiCryptoEngine[]> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_KMS_API_BASE_URL()}/engines`, {
-        headers: { 'Authorization': `Bearer ${accessToken}` },
-    });
+    const response = await apiFetch(`${get_KMS_API_BASE_URL()}/engines`);
     if (!response.ok) {
         let errorJson;
         let errorMessage = `Failed to fetch crypto engines. HTTP error ${response.status}`;
@@ -69,13 +66,10 @@ export async function fetchCryptoEngines(): Promise<ApiCryptoEngine[]> {
 }
 
 export async function fetchKmsKeys(params: URLSearchParams): Promise<ApiKmsKeyListResponse> {
-    const accessToken = requireAccessToken();
     const url = new URL(`${get_KMS_API_BASE_URL()}/keys`);
     params.forEach((value, key) => url.searchParams.append(key, value));
     
-    const response = await fetch(url.toString(), {
-        headers: { 'Authorization': `Bearer ${accessToken}` },
-    });
+    const response = await apiFetch(url.toString());
     if (!response.ok) {
         let errorJson;
         let errorMessage = `Failed to fetch KMS keys. HTTP error ${response.status}`;
@@ -91,10 +85,7 @@ export async function fetchKmsKeys(params: URLSearchParams): Promise<ApiKmsKeyLi
 }
 
 export async function fetchKmsKey(keyId: string): Promise<ApiKmsKey> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_KMS_API_BASE_URL()}/keys/${encodeURIComponent(keyId)}`, {
-        headers: { 'Authorization': `Bearer ${accessToken}` },
-    });
+    const response = await apiFetch(`${get_KMS_API_BASE_URL()}/keys/${encodeURIComponent(keyId)}`);
     if (!response.ok) {
         let errorJson;
         let errorMessage = `Failed to fetch KMS key. HTTP error ${response.status}`;
@@ -110,12 +101,10 @@ export async function fetchKmsKey(keyId: string): Promise<ApiKmsKey> {
 }
 
 export async function signWithKmsKey(keyId: string, payload: any): Promise<any> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_KMS_API_BASE_URL()}/keys/${encodeURIComponent(keyId)}/sign`, {
+    const response = await apiFetch(`${get_KMS_API_BASE_URL()}/keys/${encodeURIComponent(keyId)}/sign`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${accessToken}`,
         },
         body: JSON.stringify(payload)
     });
@@ -127,12 +116,10 @@ export async function signWithKmsKey(keyId: string, payload: any): Promise<any> 
 }
 
 export async function verifyWithKmsKey(keyId: string, payload: any): Promise<{ valid: boolean }> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_KMS_API_BASE_URL()}/keys/${encodeURIComponent(keyId)}/verify`, {
+    const response = await apiFetch(`${get_KMS_API_BASE_URL()}/keys/${encodeURIComponent(keyId)}/verify`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${accessToken}`,
         },
         body: JSON.stringify(payload)
     });
@@ -153,12 +140,10 @@ export async function verifyWithKmsKey(keyId: string, payload: any): Promise<{ v
 }
 
 export async function createKmsKey(payload: CreateKmsKeyPayload): Promise<ApiKmsKey> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_KMS_API_BASE_URL()}/keys`, {
+    const response = await apiFetch(`${get_KMS_API_BASE_URL()}/keys`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${accessToken}`,
         },
         body: JSON.stringify(payload)
     });
@@ -177,12 +162,10 @@ export async function createKmsKey(payload: CreateKmsKeyPayload): Promise<ApiKms
 }
 
 export async function importKmsKey(payload: ImportKmsKeyPayload): Promise<ApiKmsKey> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_KMS_API_BASE_URL()}/keys/import`, {
+    const response = await apiFetch(`${get_KMS_API_BASE_URL()}/keys/import`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${accessToken}`,
         },
         body: JSON.stringify(payload)
     });
@@ -201,10 +184,8 @@ export async function importKmsKey(payload: ImportKmsKeyPayload): Promise<ApiKms
 }
 
 export async function deleteKmsKey(keyId: string): Promise<void> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_KMS_API_BASE_URL()}/keys/${encodeURIComponent(keyId)}`, {
+    const response = await apiFetch(`${get_KMS_API_BASE_URL()}/keys/${encodeURIComponent(keyId)}`, {
         method: 'DELETE',
-        headers: { 'Authorization': `Bearer ${accessToken}` },
     });
 
     if (!response.ok) {
@@ -227,12 +208,10 @@ export interface PatchOperation {
 }
 
 export async function updateKeyAliases(keyId: string, patches: PatchOperation[]): Promise<void> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_KMS_API_BASE_URL()}/keys/${encodeURIComponent(keyId)}/alias`, {
+    const response = await apiFetch(`${get_KMS_API_BASE_URL()}/keys/${encodeURIComponent(keyId)}/alias`, {
         method: 'PUT',
         headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${accessToken}`,
         },
         body: JSON.stringify({ key_id: keyId, patches })
     });
@@ -250,12 +229,10 @@ export async function updateKeyAliases(keyId: string, patches: PatchOperation[])
 }
 
 export async function updateKeyTags(keyId: string, tags: string[]): Promise<void> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_KMS_API_BASE_URL()}/keys/${encodeURIComponent(keyId)}/tags`, {
+    const response = await apiFetch(`${get_KMS_API_BASE_URL()}/keys/${encodeURIComponent(keyId)}/tags`, {
         method: 'PUT',
         headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${accessToken}`,
         },
         body: JSON.stringify({ tags })
     });
@@ -273,12 +250,10 @@ export async function updateKeyTags(keyId: string, tags: string[]): Promise<void
 }
 
 export async function updateKeyMetadata(keyId: string, patchOperations: PatchOperation[]): Promise<void> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_KMS_API_BASE_URL()}/keys/${encodeURIComponent(keyId)}/metadata`, {
+    const response = await apiFetch(`${get_KMS_API_BASE_URL()}/keys/${encodeURIComponent(keyId)}/metadata`, {
         method: 'PUT',
         headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${accessToken}`,
         },
         body: JSON.stringify({ patches: patchOperations }),
     });

--- a/src/lib/va-api.ts
+++ b/src/lib/va-api.ts
@@ -2,7 +2,7 @@
 
 // src/lib/va-api.ts
 import { get_VA_API_BASE_URL, get_VA_CORE_API_BASE_URL, handleApiError } from './api-domains';
-import { requireAccessToken } from './auth-session';
+import { apiFetch } from './api-client';
 import { checkOcspStatus, type OcspResponseDetails } from '@/lib-crypto';
 
 export type { OcspResponseDetails };
@@ -48,10 +48,7 @@ export interface VaUpdatePayload {
  * Throws an error for other failures.
  */
 export async function fetchVaConfig(ski: string): Promise<VaApiResponse | null> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_VA_API_BASE_URL()}/roles/${ski}`, {
-        headers: { 'Authorization': `Bearer ${accessToken}` },
-    });
+    const response = await apiFetch(`${get_VA_API_BASE_URL()}/roles/${ski}`);
 
     if (response.status === 404) {
         return null; // Not found, which is a valid state (means not configured yet)
@@ -65,12 +62,10 @@ export async function fetchVaConfig(ski: string): Promise<VaApiResponse | null> 
  * Creates or updates the VA configuration for a given CA Subject Key ID (SKI).
  */
 export async function updateVaConfig(ski: string, payload: VaUpdatePayload): Promise<void> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_VA_API_BASE_URL()}/roles/${ski}`, {
+    const response = await apiFetch(`${get_VA_API_BASE_URL()}/roles/${ski}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${accessToken}`,
         },
         body: JSON.stringify(payload),
     });
@@ -87,10 +82,8 @@ export async function updateVaConfig(ski: string, payload: VaUpdatePayload): Pro
  * Returns the CRL data as an ArrayBuffer.
  */
 export async function downloadCrl(ski: string): Promise<ArrayBuffer> {
-    const accessToken = requireAccessToken();
-    const response = await fetch(`${get_VA_CORE_API_BASE_URL()}/crl/${ski}`, {
+    const response = await apiFetch(`${get_VA_CORE_API_BASE_URL()}/crl/${ski}`, {
         headers: {
-            'Authorization': `Bearer ${accessToken}`,
             'Accept': 'application/pkix-crl',
         },
     });


### PR DESCRIPTION
This pull request primarily improves authentication handling and error messaging throughout the codebase. It introduces a utility to check if authentication is disabled, updates error messages for clarity, refactors the authentication context provider for stability, and adds comprehensive tests for authentication session logic.

**Authentication logic improvements:**

* Added an `isAuthDisabled` utility function in `auth-session.ts` to reliably detect when authentication is disabled, and updated `requireAccessToken` to return an empty string instead of throwing when auth is disabled and no token is present. [[1]](diffhunk://#diff-e0fea8ebd116051c49e102373f3817e34d6dba892990c6af1ace62734d3728f7R3-R10) [[2]](diffhunk://#diff-e0fea8ebd116051c49e102373f3817e34d6dba892990c6af1ace62734d3728f7R39-R42)
* Refactored `AuthProvider` in `AuthContext.tsx` to always compute and memoize the context value, ensuring hook order stability and preventing unnecessary re-renders when authentication mode changes. [[1]](diffhunk://#diff-cf239e897193b2687998acaf21bc04a2e009dcf7253005cdf7fb92da6afc25fbL234-R237) [[2]](diffhunk://#diff-cf239e897193b2687998acaf21bc04a2e009dcf7253005cdf7fb92da6afc25fbL254-R269)

**Testing enhancements:**

* Added `auth-session.test.ts` to thoroughly test `requireAccessToken` behavior under different authentication modes and token presence scenarios.

**User-facing error message updates:**

* Updated error messages in multiple components to remove references to authentication status, focusing only on the relevant missing item (e.g., "No integration selected" instead of "No integration selected or user not authenticated"). [[1]](diffhunk://#diff-12b80643fa8896af7cc2d92aead3542c79a81a0e8410408687abe862b3f8c06aL88-R88) [[2]](diffhunk://#diff-dfd6ab526fe4aac37bb95acbab41f4e4a864c4125c6183937f745e9ade7a20a9L185-R185) [[3]](diffhunk://#diff-1f3d49cb42edda2720a90639bdc253af22dddf5978f375cce9c1b0c4b21cbb93L118-R118) [[4]](diffhunk://#diff-41509d48074eb625e5444e6151bc723aa1f8c0834c79781e3bb2f0b348529681L192-R192)