### PR TITLE
feat(RA): add CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK combined auth mode

### DIFF
--- a/src/app/registration-authorities/new/page.tsx
+++ b/src/app/registration-authorities/new/page.tsx
@@ -202,15 +202,16 @@ export default function CreateOrEditRegistrationAuthorityPage() {
 
         const authSettings = enrollment_settings.est_rfc7030_settings;
         if (authSettings) {
-            const authModeMap: { [key: string]: string } = { 'CLIENT_CERTIFICATE': 'Client Certificate', 'EXTERNAL_WEBHOOK': 'External Webhook', 'NONE': 'No Auth' };
+            const authModeMap: { [key: string]: string } = { 'CLIENT_CERTIFICATE': 'Client Certificate', 'EXTERNAL_WEBHOOK': 'External Webhook', 'NONE': 'No Auth', 'CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK': 'Client Certificate + Webhook' };
             const currentAuthMode = authModeMap[authSettings.auth_mode] || 'Client Certificate';
             setAuthMode(currentAuthMode);
             
-            if (currentAuthMode === 'Client Certificate' && authSettings.client_certificate_settings) {
+            if ((currentAuthMode === 'Client Certificate' || currentAuthMode === 'Client Certificate + Webhook') && authSettings.client_certificate_settings) {
                 setChainValidationLevel(authSettings.client_certificate_settings.chain_level_validation);
                 setAllowExpiredAuth(authSettings.client_certificate_settings.allow_expired);
                 setValidationCAs(authSettings.client_certificate_settings.validation_cas.map(id => findCaById(id, availableCAsForSelection)).filter(Boolean) as CA[]);
-            } else if (currentAuthMode === 'External Webhook' && authSettings.external_webhook_settings) {
+            }
+            if ((currentAuthMode === 'External Webhook' || currentAuthMode === 'Client Certificate + Webhook') && authSettings.external_webhook_settings) {
                 const webhookSettings = authSettings.external_webhook_settings;
                 setWebhookName(webhookSettings.name || '');
                 setWebhookUrl(webhookSettings.url || '');
@@ -295,19 +296,20 @@ export default function CreateOrEditRegistrationAuthorityPage() {
         return;
     }
     const protocolMapping: { [key: string]: string } = { 'EST': 'EST_RFC7030', 'None': '' };
-    const authModeMapping = { 'Client Certificate': 'CLIENT_CERTIFICATE', 'External Webhook': 'EXTERNAL_WEBHOOK', 'No Auth': 'NONE' };
+    const authModeMapping = { 'Client Certificate': 'CLIENT_CERTIFICATE', 'External Webhook': 'EXTERNAL_WEBHOOK', 'No Auth': 'NONE', 'Client Certificate + Webhook': 'CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK' };
     
     const estSettings: any = {
         auth_mode: authModeMapping[authMode as keyof typeof authModeMapping],
     };
 
-    if (authMode === 'Client Certificate') {
+    if (authMode === 'Client Certificate' || authMode === 'Client Certificate + Webhook') {
         estSettings.client_certificate_settings = {
             chain_level_validation: chainValidationLevel,
             validation_cas: validationCAs.map(ca => ca.id),
             allow_expired: allowExpiredAuth,
         };
-    } else if (authMode === 'External Webhook') {
+    }
+    if (authMode === 'External Webhook' || authMode === 'Client Certificate + Webhook') {
         const webhookAuthModeMapping: { [key: string]: string } = { 'No Auth': 'NO_AUTH', 'OIDC': 'OIDC', 'API Key': 'API_KEY' };
         const webhookConfig: any = {
             validate_server_cert: webhookValidateServerCert,
@@ -692,9 +694,9 @@ export default function CreateOrEditRegistrationAuthorityPage() {
                 </div>
                 <Switch id="verifyCsrSignature" checked={verifyCsrSignature} onCheckedChange={setVerifyCsrSignature} />
               </div>
-              <div><Label htmlFor="authMode">Authentication Mode</Label><Select value={authMode} onValueChange={setAuthMode}><SelectTrigger id="authMode" className="mt-1"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="Client Certificate">Client Certificate</SelectItem><SelectItem value="External Webhook">External Webhook</SelectItem><SelectItem value="No Auth">No Auth</SelectItem></SelectContent></Select></div>
+              <div><Label htmlFor="authMode">Authentication Mode</Label><Select value={authMode} onValueChange={setAuthMode}><SelectTrigger id="authMode" className="mt-1"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="Client Certificate">Client Certificate</SelectItem><SelectItem value="External Webhook">External Webhook</SelectItem><SelectItem value="Client Certificate + Webhook">Client Certificate + Webhook</SelectItem><SelectItem value="No Auth">No Auth</SelectItem></SelectContent></Select></div>
               
-              {authMode === 'Client Certificate' && (
+              {(authMode === 'Client Certificate' || authMode === 'Client Certificate + Webhook') && (
                   <div className="space-y-4 pt-2 border-t mt-4">
                       <h4 className="font-medium text-md text-muted-foreground pt-2">Client Certificate Auth Settings</h4>
                       <div>
@@ -722,7 +724,7 @@ export default function CreateOrEditRegistrationAuthorityPage() {
                   </div>
               )}
 
-              {authMode === 'External Webhook' && (
+              {(authMode === 'External Webhook' || authMode === 'Client Certificate + Webhook') && (
                   <div className="space-y-4 pt-2 border-t mt-4">
                       <h4 className="font-medium text-md text-muted-foreground pt-2">Webhook Settings</h4>
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/src/lib/dms-api.test.ts
+++ b/src/lib/dms-api.test.ts
@@ -515,6 +515,148 @@ describe('dms-api', () => {
       expect(webhookSettings?.config.log_level).toBe('Warn')
     })
 
+    it('should fetch RA with combined CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK auth mode', async () => {
+      const raWithCombinedAuth: ApiRaItem = {
+        ...mockRa,
+        settings: {
+          ...mockRa.settings,
+          enrollment_settings: {
+            ...mockRa.settings.enrollment_settings,
+            est_rfc7030_settings: {
+              auth_mode: 'CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK',
+              client_certificate_settings: {
+                chain_level_validation: 2,
+                validation_cas: ['ca-1', 'ca-2'],
+                allow_expired: false,
+              },
+              external_webhook_settings: {
+                name: 'combined-webhook',
+                url: 'https://auth.example.com/validate',
+                log_level: 'Info',
+                auth_mode: 'NO_AUTH',
+              },
+            },
+          },
+        },
+      }
+
+      server.use(
+        http.get(`${DMS_API_BASE}/dms/${raWithCombinedAuth.id}`, () => {
+          return HttpResponse.json(raWithCombinedAuth)
+        })
+      )
+
+      const result = await fetchRaById(raWithCombinedAuth.id)
+      const estSettings = result.settings.enrollment_settings.est_rfc7030_settings
+
+      expect(estSettings).toBeDefined()
+      expect(estSettings?.auth_mode).toBe('CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK')
+      expect(estSettings?.client_certificate_settings).toBeDefined()
+      expect(estSettings?.client_certificate_settings?.validation_cas).toEqual(['ca-1', 'ca-2'])
+      expect(estSettings?.external_webhook_settings).toBeDefined()
+      expect(estSettings?.external_webhook_settings?.name).toBe('combined-webhook')
+    })
+
+    it('should create RA with combined auth mode including both settings blocks', async () => {
+      let capturedBody: any
+
+      server.use(
+        http.post(`${DMS_API_BASE}/dms`, async ({ request }) => {
+          capturedBody = await request.json()
+          return HttpResponse.json(mockRa)
+        })
+      )
+
+      const payload: RaCreationPayload = {
+        id: 'ra-combined',
+        name: 'RA Combined Auth',
+        metadata: {},
+        settings: {
+          ...mockRa.settings,
+          enrollment_settings: {
+            ...mockRa.settings.enrollment_settings,
+            est_rfc7030_settings: {
+              auth_mode: 'CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK',
+              client_certificate_settings: {
+                chain_level_validation: -1,
+                validation_cas: ['ca-1'],
+                allow_expired: true,
+              },
+              external_webhook_settings: {
+                name: 'my-webhook',
+                url: 'https://hooks.example.com/verify',
+                log_level: 'Info',
+                auth_mode: 'API_KEY',
+                api_key_auth: {
+                  key: 'super-secret-key',
+                },
+              },
+            },
+          },
+        },
+      }
+
+      await createOrUpdateRa(payload, false)
+
+      const estSettings = capturedBody.settings.enrollment_settings.est_rfc7030_settings
+      expect(estSettings.auth_mode).toBe('CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK')
+      expect(estSettings.client_certificate_settings).toBeDefined()
+      expect(estSettings.client_certificate_settings.validation_cas).toEqual(['ca-1'])
+      expect(estSettings.external_webhook_settings).toBeDefined()
+      expect(estSettings.external_webhook_settings.auth_mode).toBe('API_KEY')
+      expect(estSettings.external_webhook_settings.api_key_auth.key).toBe('super-secret-key')
+    })
+
+    it('should create RA with combined auth mode and OIDC webhook', async () => {
+      let capturedBody: any
+
+      server.use(
+        http.post(`${DMS_API_BASE}/dms`, async ({ request }) => {
+          capturedBody = await request.json()
+          return HttpResponse.json(mockRa)
+        })
+      )
+
+      const payload: RaCreationPayload = {
+        id: 'ra-combined-oidc',
+        name: 'RA Combined Auth OIDC',
+        metadata: {},
+        settings: {
+          ...mockRa.settings,
+          enrollment_settings: {
+            ...mockRa.settings.enrollment_settings,
+            est_rfc7030_settings: {
+              auth_mode: 'CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK',
+              client_certificate_settings: {
+                chain_level_validation: 1,
+                validation_cas: ['ca-1'],
+                allow_expired: false,
+              },
+              external_webhook_settings: {
+                name: 'oidc-webhook',
+                url: 'https://hooks.example.com/verify',
+                log_level: 'Debug',
+                auth_mode: 'OIDC',
+                oidc_auth: {
+                  client_id: 'my-client',
+                  client_secret: 'my-secret',
+                  well_known_url: 'https://idp.example.com/.well-known/openid-configuration',
+                },
+              },
+            },
+          },
+        },
+      }
+
+      await createOrUpdateRa(payload, false)
+
+      const estSettings = capturedBody.settings.enrollment_settings.est_rfc7030_settings
+      expect(estSettings.auth_mode).toBe('CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK')
+      expect(estSettings.client_certificate_settings.chain_level_validation).toBe(1)
+      expect(estSettings.external_webhook_settings.auth_mode).toBe('OIDC')
+      expect(estSettings.external_webhook_settings.oidc_auth.client_id).toBe('my-client')
+    })
+
     it('should handle createOrUpdateRa error without JSON response', async () => {
       const payload: RaCreationPayload = {
         id: 'ra-error',


### PR DESCRIPTION
### Context

The EST enrollment flow in Registration Authorities previously supported three mutually exclusive authentication modes: `CLIENT_CERTIFICATE`, `EXTERNAL_WEBHOOK`, and `NONE`. Some deployments require both mTLS client certificate validation and an external webhook check to run together during enrollment/reenrollment. This PR adds support for that combined mode.

### Updated RA form

<img width="1899" height="812" alt="image" src="https://github.com/user-attachments/assets/0af4b02c-4da1-4a6a-8fe1-b30a1089fcca" />


### Backend contract
The backend call is unchanged. When the combined mode is selected, the `est_rfc7030_settings` object is sent with `auth_mode: "CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK"` and both sub-objects populated — exactly as the API expects.

Closes #165 