### PR TITLE
feat(RA): add dedicated re-enrollment auth configuration flow

### DIFF
--- a/src/app/registration-authorities/new/page.tsx
+++ b/src/app/registration-authorities/new/page.tsx
@@ -11,8 +11,7 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { ArrowLeft, PlusCircle, Cpu, HelpCircle, Settings, Key, Server, PackageCheck, AlertTriangle, Loader2, Tag as TagIconLucide, Edit, X } from "lucide-react";
-import type { CA } from '@/lib/ca-data';
-import { fetchAndProcessCAs, findCaById, fetchSigningProfiles, type ApiSigningProfile } from '@/lib/ca-data';
+import { fetchAndProcessCAs, findCaById, fetchSigningProfiles, type ApiSigningProfile, type CA } from '@/lib/ca-data';
 import { fetchCryptoEngines } from '@/lib/kms-data';
 import { Tooltip, TooltipProvider, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { CaVisualizerCard } from '@/components/CaVisualizerCard';
@@ -93,6 +92,24 @@ export default function CreateOrEditRegistrationAuthorityPage() {
   const [validationCAs, setValidationCAs] = useState<CA[]>([]);
   const [allowExpiredAuth, setAllowExpiredAuth] = useState(true);
   const [chainValidationLevel, setChainValidationLevel] = useState(-1);
+
+  // Re-enrollment authentication state
+  const [reEnrollmentAuthMode, setReEnrollmentAuthMode] = useState('Client Certificate');
+  const [allowExpiredReAuth, setAllowExpiredReAuth] = useState(true);
+  const [reChainValidationLevel, setReChainValidationLevel] = useState(-1);
+
+  const [reWebhookName, setReWebhookName] = useState('');
+  const [reWebhookUrl, setReWebhookUrl] = useState('');
+  const [reWebhookMethod, setReWebhookMethod] = useState('POST');
+  const [reWebhookValidateServerCert, setReWebhookValidateServerCert] = useState(true);
+  const [reWebhookLogLevel, setReWebhookLogLevel] = useState('Info');
+  const [reWebhookAuthMode, setReWebhookAuthMode] = useState('No Auth');
+  const [reWebhookApiKey, setReWebhookApiKey] = useState('');
+  const [reWebhookApiKeyHeader, setReWebhookApiKeyHeader] = useState('X-API-Key');
+
+  const [reOidcClientId, setReOidcClientId] = useState('');
+  const [reOidcClientSecret, setReOidcClientSecret] = useState('');
+  const [reOidcWellKnownUrl, setReOidcWellKnownUrl] = useState('');
   
   // Webhook state
   const [webhookName, setWebhookName] = useState('');
@@ -115,6 +132,7 @@ export default function CreateOrEditRegistrationAuthorityPage() {
   const [allowedRenewalDelta, setAllowedRenewalDelta] = useState('100d');
   const [preventiveRenewalDelta, setPreventiveRenewalDelta] = useState('31d');
   const [criticalRenewalDelta, setCriticalRenewalDelta] = useState('7d');
+  const [reEnrollmentValidationCAs, setReEnrollmentValidationCAs] = useState<CA[]>([]);
   const [additionalValidationCAs, setAdditionalValidationCAs] = useState<CA[]>([]);
   const [enableKeyGeneration, setEnableKeyGeneration] = useState(false);
   const [serverKeygenType, setServerKeygenType] = useState('RSA');
@@ -130,6 +148,7 @@ export default function CreateOrEditRegistrationAuthorityPage() {
   const [isDeviceIconModalOpen, setIsDeviceIconModalOpen] = useState(false);
   const [isEnrollmentCaModalOpen, setIsEnrollmentCaModalOpen] = useState(false);
   const [isValidationCaModalOpen, setIsValidationCaModalOpen] = useState(false);
+  const [isReEnrollmentValidationCaModalOpen, setIsReEnrollmentValidationCaModalOpen] = useState(false);
   const [isAdditionalValidationCaModalOpen, setIsAdditionalValidationCaModalOpen] = useState(false);
   const [isManagedCaModalOpen, setIsManagedCaModalOpen] = useState(false);
   const [availableCAsForSelection, setAvailableCAsForSelection] = useState<CA[]>([]);
@@ -250,6 +269,43 @@ export default function CreateOrEditRegistrationAuthorityPage() {
         setCriticalRenewalDelta(reenrollment_settings.critical_delta);
         setAdditionalValidationCAs(reenrollment_settings.additional_validation_cas.map(id => findCaById(id, availableCAsForSelection)).filter(Boolean) as CA[]);
 
+        const reAuthSettings = reenrollment_settings.est_rfc7030_settings;
+        if (reAuthSettings) {
+          const authModeMap: { [key: string]: string } = { 'CLIENT_CERTIFICATE': 'Client Certificate', 'EXTERNAL_WEBHOOK': 'External Webhook', 'NONE': 'No Auth', 'CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK': 'Client Certificate + Webhook' };
+          const currentReAuthMode = authModeMap[reAuthSettings.auth_mode] || 'Client Certificate';
+          setReEnrollmentAuthMode(currentReAuthMode);
+
+          if ((currentReAuthMode === 'Client Certificate' || currentReAuthMode === 'Client Certificate + Webhook') && reAuthSettings.client_certificate_settings) {
+            setReChainValidationLevel(reAuthSettings.client_certificate_settings.chain_level_validation);
+            setAllowExpiredReAuth(reAuthSettings.client_certificate_settings.allow_expired);
+            setReEnrollmentValidationCAs(reAuthSettings.client_certificate_settings.validation_cas.map(id => findCaById(id, availableCAsForSelection)).filter(Boolean) as CA[]);
+          }
+
+          if ((currentReAuthMode === 'External Webhook' || currentReAuthMode === 'Client Certificate + Webhook') && reAuthSettings.external_webhook_settings) {
+            const webhookSettings = reAuthSettings.external_webhook_settings;
+            setReWebhookName(webhookSettings.name || '');
+            setReWebhookUrl(webhookSettings.url || '');
+            setReWebhookMethod(webhookSettings.method || 'POST');
+            setReWebhookValidateServerCert(webhookSettings.config.validate_server_cert ?? false);
+            setReWebhookLogLevel(webhookSettings.config.log_level || 'Info');
+
+            const apiWebhookAuthMode = webhookSettings.config.auth_mode;
+            let uiWebhookAuthMode = 'No Auth';
+            if (apiWebhookAuthMode === 'OIDC') uiWebhookAuthMode = 'OIDC';
+            if (apiWebhookAuthMode === 'API_KEY') uiWebhookAuthMode = 'API Key';
+            setReWebhookAuthMode(uiWebhookAuthMode);
+
+            if (uiWebhookAuthMode === 'API Key' && webhookSettings.config.apikey) {
+              setReWebhookApiKey(webhookSettings.config.apikey.key || '');
+              setReWebhookApiKeyHeader(webhookSettings.config.apikey.header || 'X-API-Key');
+            } else if (uiWebhookAuthMode === 'OIDC' && webhookSettings.config.oidc) {
+              setReOidcClientId(webhookSettings.config.oidc.client_id || '');
+              setReOidcClientSecret(webhookSettings.config.oidc.client_secret || '');
+              setReOidcWellKnownUrl(webhookSettings.config.oidc.well_known || '');
+            }
+          }
+        }
+
         setEnableKeyGeneration(server_keygen_settings.enabled);
         if (server_keygen_settings.enabled && server_keygen_settings.key) {
             setServerKeygenType(server_keygen_settings.key.type);
@@ -336,6 +392,45 @@ export default function CreateOrEditRegistrationAuthorityPage() {
         };
     }
 
+      const reEnrollmentEstSettings: any = {
+        auth_mode: authModeMapping[reEnrollmentAuthMode as keyof typeof authModeMapping],
+      };
+
+      if (reEnrollmentAuthMode === 'Client Certificate' || reEnrollmentAuthMode === 'Client Certificate + Webhook') {
+        reEnrollmentEstSettings.client_certificate_settings = {
+          chain_level_validation: reChainValidationLevel,
+          validation_cas: reEnrollmentValidationCAs.map(ca => ca.id),
+          allow_expired: allowExpiredReAuth,
+        };
+      }
+
+      if (reEnrollmentAuthMode === 'External Webhook' || reEnrollmentAuthMode === 'Client Certificate + Webhook') {
+        const webhookAuthModeMapping: { [key: string]: string } = { 'No Auth': 'NO_AUTH', 'OIDC': 'OIDC', 'API Key': 'API_KEY' };
+        const reWebhookConfig: any = {
+          validate_server_cert: reWebhookValidateServerCert,
+          log_level: reWebhookLogLevel,
+          auth_mode: webhookAuthModeMapping[reWebhookAuthMode],
+        };
+        if (reWebhookAuthMode === 'API Key') {
+          reWebhookConfig.apikey = {
+            key: reWebhookApiKey,
+            header: reWebhookApiKeyHeader,
+          };
+        } else if (reWebhookAuthMode === 'OIDC') {
+          reWebhookConfig.oidc = {
+            client_id: reOidcClientId,
+            client_secret: reOidcClientSecret,
+            well_known: reOidcWellKnownUrl,
+          };
+        }
+        reEnrollmentEstSettings.external_webhook_settings = {
+          name: reWebhookName,
+          url: reWebhookUrl,
+          method: reWebhookMethod,
+          config: reWebhookConfig,
+        };
+      }
+
 
     let keySettings;
     if (enableKeyGeneration) {
@@ -370,6 +465,7 @@ export default function CreateOrEditRegistrationAuthorityPage() {
           preventive_delta: preventiveRenewalDelta,
           reenrollment_delta: allowedRenewalDelta,
           additional_validation_cas: additionalValidationCAs.map(ca => ca.id),
+          est_rfc7030_settings: reEnrollmentEstSettings,
         },
         server_keygen_settings: {
           enabled: enableKeyGeneration,
@@ -418,6 +514,17 @@ export default function CreateOrEditRegistrationAuthorityPage() {
 
   const handleRemoveAdditionalValidationCa = (caId: string) => {
     setAdditionalValidationCAs(prev => prev.filter(vca => vca.id !== caId));
+  }
+
+  const handleAddReEnrollmentValidationCa = (ca: CA) => {
+    if (!reEnrollmentValidationCAs.some(vca => vca.id === ca.id)) {
+      setReEnrollmentValidationCAs(prev => [...prev, ca]);
+    }
+    setIsReEnrollmentValidationCaModalOpen(false);
+  }
+
+  const handleRemoveReEnrollmentValidationCa = (caId: string) => {
+    setReEnrollmentValidationCAs(prev => prev.filter(vca => vca.id !== caId));
   }
 
   const handleAddManagedCa = (ca: CA) => {
@@ -851,26 +958,169 @@ export default function CreateOrEditRegistrationAuthorityPage() {
                   <DurationInput id="allowedRenewalDelta" label="Allowed Renewal Delta" value={allowedRenewalDelta} onChange={setAllowedRenewalDelta} placeholder="e.g., 100d" description="Max time after expiry a cert can be renewed."/>
                   <DurationInput id="preventiveRenewalDelta" label="Preventive Renewal Delta" value={preventiveRenewalDelta} onChange={setPreventiveRenewalDelta} placeholder="e.g., 31d" description="Time before expiry to start allowing renewals."/>
                   <DurationInput id="criticalRenewalDelta" label="Critical Renewal Delta" value={criticalRenewalDelta} onChange={setCriticalRenewalDelta} placeholder="e.g., 7d" description="Time before expiry when renewal is critical."/>
+
                   <div>
                     <Label htmlFor="additionalValidationCAs">Additional Validation CAs (for re-enrollment)</Label>
                     <div className="mt-2 space-y-2">
-                            {additionalValidationCAs.length > 0 ? (
-                                additionalValidationCAs.map(ca => (
-                                    <div key={ca.id} className="flex items-center gap-2 group">
-                                        <CaVisualizerCard ca={ca} allCryptoEngines={allCryptoEngines} className="flex-grow shadow-none border-border" />
-                                        <Button type="button" variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-destructive opacity-50 group-hover:opacity-100" onClick={() => handleRemoveAdditionalValidationCa(ca.id)}>
-                                            <X className="h-4 w-4" />
-                                        </Button>
-                                    </div>
-                                ))
-                            ) : (
-                                <p className="text-sm text-muted-foreground italic text-center p-2">No additional validation CAs selected.</p>
-                            )}
-                        </div>
-                        <Button type="button" variant="outline" size="sm" onClick={() => setIsAdditionalValidationCaModalOpen(true)} className="mt-2">
-                           <PlusCircle className="mr-2 h-4 w-4" /> Add Additional Validation CA
-                        </Button>
+                      {additionalValidationCAs.length > 0 ? (
+                        additionalValidationCAs.map(ca => (
+                          <div key={ca.id} className="flex items-center gap-2 group">
+                            <CaVisualizerCard ca={ca} allCryptoEngines={allCryptoEngines} className="flex-grow shadow-none border-border" />
+                            <Button type="button" variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-destructive opacity-50 group-hover:opacity-100" onClick={() => handleRemoveAdditionalValidationCa(ca.id)}>
+                              <X className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        ))
+                      ) : (
+                        <p className="text-sm text-muted-foreground italic text-center p-2">No additional validation CAs selected.</p>
+                      )}
+                    </div>
+                    <Button type="button" variant="outline" size="sm" onClick={() => setIsAdditionalValidationCaModalOpen(true)} className="mt-2">
+                      <PlusCircle className="mr-2 h-4 w-4" /> Add Additional Validation CA
+                    </Button>
                   </div>
+
+                  <div>
+                    <Label htmlFor="reEnrollmentAuthMode">Re-Enrollment Authentication Mode</Label>
+                    <Select value={reEnrollmentAuthMode} onValueChange={setReEnrollmentAuthMode}>
+                      <SelectTrigger id="reEnrollmentAuthMode" className="mt-1"><SelectValue /></SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="Client Certificate">Client Certificate</SelectItem>
+                        <SelectItem value="External Webhook">External Webhook</SelectItem>
+                        <SelectItem value="Client Certificate + Webhook">Client Certificate + Webhook</SelectItem>
+                        <SelectItem value="No Auth">No Auth</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  {(reEnrollmentAuthMode === 'Client Certificate' || reEnrollmentAuthMode === 'Client Certificate + Webhook') && (
+                    <div className="space-y-4 pt-2 border-t mt-4">
+                      <h4 className="font-medium text-md text-muted-foreground pt-2">Client Certificate Re-Enrollment Auth Settings</h4>
+                      <div>
+                        <Label htmlFor="reEnrollmentValidationCAs">Validation CAs</Label>
+                        <div className="mt-2 space-y-2">
+                          {reEnrollmentValidationCAs.length > 0 ? (
+                            reEnrollmentValidationCAs.map(ca => (
+                              <div key={ca.id} className="flex items-center gap-2 group">
+                                <CaVisualizerCard ca={ca} allCryptoEngines={allCryptoEngines} className="flex-grow shadow-none border-border" />
+                                <Button type="button" variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-destructive opacity-50 group-hover:opacity-100" onClick={() => handleRemoveReEnrollmentValidationCa(ca.id)}>
+                                  <X className="h-4 w-4" />
+                                </Button>
+                              </div>
+                            ))
+                          ) : (
+                            <p className="text-sm text-muted-foreground italic text-center p-2">No validation CAs selected.</p>
+                          )}
+                        </div>
+                        <Button type="button" variant="outline" size="sm" onClick={() => setIsReEnrollmentValidationCaModalOpen(true)} className="mt-2">
+                          <PlusCircle className="mr-2 h-4 w-4" /> Add Validation CA
+                        </Button>
+                      </div>
+                      <div className="flex items-center space-x-2 pt-2">
+                        <Switch id="allowExpiredReAuth" checked={allowExpiredReAuth} onCheckedChange={setAllowExpiredReAuth} />
+                        <Label htmlFor="allowExpiredReAuth">Allow Authenticating Expired Certificates</Label>
+                      </div>
+                      <div>
+                        <Label htmlFor="reChainValidationLevel" className="flex items-center">
+                          Chain Validation Level
+                          <TooltipProvider><Tooltip><TooltipTrigger asChild><HelpCircle className="ml-1 h-4 w-4 text-muted-foreground cursor-help" /></TooltipTrigger><TooltipContent><p>-1 equals full chain validation.</p></TooltipContent></Tooltip></TooltipProvider>
+                        </Label>
+                        <Input id="reChainValidationLevel" type="number" value={reChainValidationLevel} onChange={(e) => setReChainValidationLevel(Number.parseInt(e.target.value))} className="mt-1" />
+                      </div>
+                    </div>
+                  )}
+
+                  {(reEnrollmentAuthMode === 'External Webhook' || reEnrollmentAuthMode === 'Client Certificate + Webhook') && (
+                    <div className="space-y-4 pt-2 border-t mt-4">
+                      <h4 className="font-medium text-md text-muted-foreground pt-2">Webhook Re-Enrollment Auth Settings</h4>
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                          <Label htmlFor="reWebhookName">Webhook Name</Label>
+                          <Input id="reWebhookName" value={reWebhookName} onChange={(e) => setReWebhookName(e.target.value)} placeholder="e.g., ReEnrollmentValidationFunc" className="mt-1" />
+                        </div>
+                        <div>
+                          <Label htmlFor="reWebhookUrl">Webhook URL</Label>
+                          <Input id="reWebhookUrl" value={reWebhookUrl} onChange={(e) => setReWebhookUrl(e.target.value)} placeholder="http://localhost:8080/verify-reenrollment" className="mt-1" />
+                        </div>
+                      </div>
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                          <Label htmlFor="reWebhookMethod">HTTP Method</Label>
+                          <Select value={reWebhookMethod} onValueChange={setReWebhookMethod}>
+                            <SelectTrigger id="reWebhookMethod" className="mt-1"><SelectValue /></SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="POST">POST</SelectItem>
+                              <SelectItem value="PUT">PUT</SelectItem>
+                            </SelectContent>
+                          </Select>
+                        </div>
+                        <div>
+                          <Label htmlFor="reWebhookLogLevel">Log Level</Label>
+                          <Select value={reWebhookLogLevel} onValueChange={setReWebhookLogLevel}>
+                            <SelectTrigger id="reWebhookLogLevel" className="mt-1"><SelectValue /></SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="Info">Info</SelectItem>
+                              <SelectItem value="Debug">Debug</SelectItem>
+                              <SelectItem value="Warn">Warn</SelectItem>
+                              <SelectItem value="Error">Error</SelectItem>
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      </div>
+                      <div className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm bg-background">
+                        <div className="space-y-0.5">
+                          <Label htmlFor="reWebhookValidateServerCert" className="flex items-center">
+                            <Server className="mr-2 h-4 w-4 text-muted-foreground" />
+                            Validate Server Certificate
+                          </Label>
+                          <p className="text-sm text-muted-foreground">
+                            Verify the TLS certificate of the webhook endpoint.
+                          </p>
+                        </div>
+                        <Switch id="reWebhookValidateServerCert" checked={reWebhookValidateServerCert} onCheckedChange={setReWebhookValidateServerCert} />
+                      </div>
+                      <div>
+                        <Label htmlFor="reWebhookAuthMode">Auth Mode</Label>
+                        <Select value={reWebhookAuthMode} onValueChange={setReWebhookAuthMode}>
+                          <SelectTrigger id="reWebhookAuthMode" className="mt-1"><SelectValue /></SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="No Auth">No Auth</SelectItem>
+                            <SelectItem value="OIDC">OIDC</SelectItem>
+                            <SelectItem value="API Key">API Key</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      {reWebhookAuthMode === 'API Key' && (
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                          <div>
+                            <Label htmlFor="reWebhookApiKey">API Key</Label>
+                            <Input id="reWebhookApiKey" type="password" value={reWebhookApiKey} onChange={e => setReWebhookApiKey(e.target.value)} placeholder="Enter API Key" className="mt-1"/>
+                          </div>
+                          <div>
+                            <Label htmlFor="reWebhookApiKeyHeader">Header Name</Label>
+                            <Input id="reWebhookApiKeyHeader" value={reWebhookApiKeyHeader} onChange={e => setReWebhookApiKeyHeader(e.target.value)} placeholder="X-API-Key" className="mt-1"/>
+                          </div>
+                        </div>
+                      )}
+                      {reWebhookAuthMode === 'OIDC' && (
+                        <div className="space-y-4 pt-2 border-t mt-4">
+                          <h5 className="font-medium text-sm text-muted-foreground pt-2">OIDC Settings</h5>
+                          <div>
+                            <Label htmlFor="reOidcClientId">Client ID</Label>
+                            <Input id="reOidcClientId" value={reOidcClientId} onChange={e => setReOidcClientId(e.target.value)} placeholder="Enter OIDC Client ID" className="mt-1"/>
+                          </div>
+                          <div>
+                            <Label htmlFor="reOidcClientSecret">Client Secret</Label>
+                            <Input id="reOidcClientSecret" type="password" value={reOidcClientSecret} onChange={e => setReOidcClientSecret(e.target.value)} placeholder="Enter OIDC Client Secret" className="mt-1"/>
+                          </div>
+                          <div>
+                            <Label htmlFor="reOidcWellKnownUrl">Well-Known URL</Label>
+                            <Input id="reOidcWellKnownUrl" value={reOidcWellKnownUrl} onChange={e => setReOidcWellKnownUrl(e.target.value)} placeholder="https://your-issuer.com/.well-known/openid-configuration" className="mt-1"/>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )}
               </SettingsCard>
 
               <SettingsCard
@@ -960,6 +1210,18 @@ export default function CreateOrEditRegistrationAuthorityPage() {
         errorCAs={errorDependencies} 
         loadCAsAction={loadDependencies} 
         onCaSelected={handleAddValidationCa}
+        allCryptoEngines={allCryptoEngines}
+      />
+      <CaSelectorModal
+        isOpen={isReEnrollmentValidationCaModalOpen}
+        onOpenChange={setIsReEnrollmentValidationCaModalOpen}
+        title="Add Re-Enrollment Validation CA"
+        description="Select a CA to add to the re-enrollment validation list."
+        availableCAs={availableCAsForSelection}
+        isLoadingCAs={isLoadingDependencies}
+        errorCAs={errorDependencies}
+        loadCAsAction={loadDependencies}
+        onCaSelected={handleAddReEnrollmentValidationCa}
         allCryptoEngines={allCryptoEngines}
       />
       <CaSelectorModal

--- a/src/app/registration-authorities/new/page.tsx
+++ b/src/app/registration-authorities/new/page.tsx
@@ -10,10 +10,9 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import { ArrowLeft, PlusCircle, Cpu, HelpCircle, Settings, Key, Server, PackageCheck, AlertTriangle, Loader2, Tag as TagIconLucide, Edit, X } from "lucide-react";
+import { ArrowLeft, PlusCircle, Cpu, Settings, Key, Server, PackageCheck, AlertTriangle, Loader2, Tag as TagIconLucide, Edit, X } from "lucide-react";
 import { fetchAndProcessCAs, findCaById, fetchSigningProfiles, type ApiSigningProfile, type CA } from '@/lib/ca-data';
 import { fetchCryptoEngines } from '@/lib/kms-data';
-import { Tooltip, TooltipProvider, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { CaVisualizerCard } from '@/components/CaVisualizerCard';
 import { CaSelectorModal } from '@/components/shared/CaSelectorModal'; 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -23,9 +22,11 @@ import { DeviceIconSelectorModal, getLucideIconByName } from '@/components/share
 import type { ApiCryptoEngine } from '@/types/crypto-engine';
 import { sileo } from '@/lib/toast';
 import { DurationInput } from '@/components/shared/DurationInput';
-import { createOrUpdateRa, fetchRaById, type ApiRaItem, type RaCreationPayload } from '@/lib/dms-api';
+import { createOrUpdateRa, fetchRaById, buildApiRaEstSettingsFromForm, createDefaultRaAuthFormValues, hydrateRaAuthFormValuesFromApi, type ApiRaItem, type RaCreationPayload } from '@/lib/dms-api';
 import { IssuanceProfileCard } from '@/components/shared/IssuanceProfileCard';
 import { DetailBreadcrumbRow } from '@/components/shared/DetailBreadcrumbRow';
+import { RaAuthConfigurationSection } from '@/components/ra/RaAuthConfigurationSection';
+import type { RaAuthFormValues } from '@/types/ra-auth';
 
 
 const serverKeygenTypes = [ { value: 'RSA', label: 'RSA' }, { value: 'ECDSA', label: 'ECDSA' }];
@@ -37,12 +38,12 @@ function SettingsCard({
   title,
   description,
   children,
-}: {
+}: Readonly<{
   icon: React.ElementType;
   title: string;
   description: string;
   children: React.ReactNode;
-}) {
+}>) {
   return (
     <Card className="overflow-hidden rounded-xl shadow-sm">
       <CardHeader className="border-b py-4">
@@ -88,43 +89,11 @@ export default function CreateOrEditRegistrationAuthorityPage() {
   const [enrollmentCa, setEnrollmentCa] = useState<CA | null>(null);
   const [allowOverrideEnrollment, setAllowOverrideEnrollment] = useState(true);
   const [verifyCsrSignature, setVerifyCsrSignature] = useState(true);
-  const [authMode, setAuthMode] = useState('Client Certificate');
+  const [enrollmentAuthConfig, setEnrollmentAuthConfig] = useState<RaAuthFormValues>(createDefaultRaAuthFormValues());
   const [validationCAs, setValidationCAs] = useState<CA[]>([]);
-  const [allowExpiredAuth, setAllowExpiredAuth] = useState(true);
-  const [chainValidationLevel, setChainValidationLevel] = useState(-1);
 
   // Re-enrollment authentication state
-  const [reEnrollmentAuthMode, setReEnrollmentAuthMode] = useState('Client Certificate');
-  const [allowExpiredReAuth, setAllowExpiredReAuth] = useState(true);
-  const [reChainValidationLevel, setReChainValidationLevel] = useState(-1);
-
-  const [reWebhookName, setReWebhookName] = useState('');
-  const [reWebhookUrl, setReWebhookUrl] = useState('');
-  const [reWebhookMethod, setReWebhookMethod] = useState('POST');
-  const [reWebhookValidateServerCert, setReWebhookValidateServerCert] = useState(true);
-  const [reWebhookLogLevel, setReWebhookLogLevel] = useState('Info');
-  const [reWebhookAuthMode, setReWebhookAuthMode] = useState('No Auth');
-  const [reWebhookApiKey, setReWebhookApiKey] = useState('');
-  const [reWebhookApiKeyHeader, setReWebhookApiKeyHeader] = useState('X-API-Key');
-
-  const [reOidcClientId, setReOidcClientId] = useState('');
-  const [reOidcClientSecret, setReOidcClientSecret] = useState('');
-  const [reOidcWellKnownUrl, setReOidcWellKnownUrl] = useState('');
-  
-  // Webhook state
-  const [webhookName, setWebhookName] = useState('');
-  const [webhookUrl, setWebhookUrl] = useState('');
-  const [webhookMethod, setWebhookMethod] = useState('POST');
-  const [webhookValidateServerCert, setWebhookValidateServerCert] = useState(true);
-  const [webhookLogLevel, setWebhookLogLevel] = useState('Info');
-  const [webhookAuthMode, setWebhookAuthMode] = useState('No Auth');
-  const [webhookApiKey, setWebhookApiKey] = useState('');
-  const [webhookApiKeyHeader, setWebhookApiKeyHeader] = useState('X-API-Key');
-  
-  // OIDC Webhook state
-  const [oidcClientId, setOidcClientId] = useState('');
-  const [oidcClientSecret, setOidcClientSecret] = useState('');
-  const [oidcWellKnownUrl, setOidcWellKnownUrl] = useState('');
+  const [reEnrollmentAuthConfig, setReEnrollmentAuthConfig] = useState<RaAuthFormValues>(createDefaultRaAuthFormValues());
 
 
   const [revokeOnReEnroll, setRevokeOnReEnroll] = useState(true);
@@ -219,41 +188,9 @@ export default function CreateOrEditRegistrationAuthorityPage() {
         setAllowOverrideEnrollment(enrollment_settings.enable_replaceable_enrollment);
         setVerifyCsrSignature(enrollment_settings.verify_csr_signature ?? true); // Default to true if not set
 
-        const authSettings = enrollment_settings.est_rfc7030_settings;
-        if (authSettings) {
-            const authModeMap: { [key: string]: string } = { 'CLIENT_CERTIFICATE': 'Client Certificate', 'EXTERNAL_WEBHOOK': 'External Webhook', 'NONE': 'No Auth', 'CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK': 'Client Certificate + Webhook' };
-            const currentAuthMode = authModeMap[authSettings.auth_mode] || 'Client Certificate';
-            setAuthMode(currentAuthMode);
-            
-            if ((currentAuthMode === 'Client Certificate' || currentAuthMode === 'Client Certificate + Webhook') && authSettings.client_certificate_settings) {
-                setChainValidationLevel(authSettings.client_certificate_settings.chain_level_validation);
-                setAllowExpiredAuth(authSettings.client_certificate_settings.allow_expired);
-                setValidationCAs(authSettings.client_certificate_settings.validation_cas.map(id => findCaById(id, availableCAsForSelection)).filter(Boolean) as CA[]);
-            }
-            if ((currentAuthMode === 'External Webhook' || currentAuthMode === 'Client Certificate + Webhook') && authSettings.external_webhook_settings) {
-                const webhookSettings = authSettings.external_webhook_settings;
-                setWebhookName(webhookSettings.name || '');
-                setWebhookUrl(webhookSettings.url || '');
-                setWebhookMethod(webhookSettings.method || 'POST');
-                setWebhookValidateServerCert(webhookSettings.config.validate_server_cert ?? false);
-                setWebhookLogLevel(webhookSettings.config.log_level || 'Info');
-                
-                const apiWebhookAuthMode = webhookSettings.config.auth_mode;
-                let uiWebhookAuthMode = 'No Auth';
-                if (apiWebhookAuthMode === 'OIDC') uiWebhookAuthMode = 'OIDC';
-                if (apiWebhookAuthMode === 'API_KEY') uiWebhookAuthMode = 'API Key';
-                setWebhookAuthMode(uiWebhookAuthMode);
-
-                if (uiWebhookAuthMode === 'API Key' && webhookSettings.config.apikey) {
-                    setWebhookApiKey(webhookSettings.config.apikey.key || '');
-                    setWebhookApiKeyHeader(webhookSettings.config.apikey.header || 'X-API-Key');
-                } else if (uiWebhookAuthMode === 'OIDC' && webhookSettings.config.oidc) {
-                    setOidcClientId(webhookSettings.config.oidc.client_id || '');
-                    setOidcClientSecret(webhookSettings.config.oidc.client_secret || '');
-                    setOidcWellKnownUrl(webhookSettings.config.oidc.well_known || '');
-                }
-            }
-        }
+        const hydratedEnrollmentAuth = hydrateRaAuthFormValuesFromApi(enrollment_settings.est_rfc7030_settings);
+        setEnrollmentAuthConfig(hydratedEnrollmentAuth);
+        setValidationCAs(hydratedEnrollmentAuth.validationCaIds.map(id => findCaById(id, availableCAsForSelection)).filter(Boolean) as CA[]);
 
         const { device_provisioning_profile } = enrollment_settings;
         setTags(device_provisioning_profile.tags);
@@ -269,42 +206,9 @@ export default function CreateOrEditRegistrationAuthorityPage() {
         setCriticalRenewalDelta(reenrollment_settings.critical_delta);
         setAdditionalValidationCAs(reenrollment_settings.additional_validation_cas.map(id => findCaById(id, availableCAsForSelection)).filter(Boolean) as CA[]);
 
-        const reAuthSettings = reenrollment_settings.est_rfc7030_settings;
-        if (reAuthSettings) {
-          const authModeMap: { [key: string]: string } = { 'CLIENT_CERTIFICATE': 'Client Certificate', 'EXTERNAL_WEBHOOK': 'External Webhook', 'NONE': 'No Auth', 'CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK': 'Client Certificate + Webhook' };
-          const currentReAuthMode = authModeMap[reAuthSettings.auth_mode] || 'Client Certificate';
-          setReEnrollmentAuthMode(currentReAuthMode);
-
-          if ((currentReAuthMode === 'Client Certificate' || currentReAuthMode === 'Client Certificate + Webhook') && reAuthSettings.client_certificate_settings) {
-            setReChainValidationLevel(reAuthSettings.client_certificate_settings.chain_level_validation);
-            setAllowExpiredReAuth(reAuthSettings.client_certificate_settings.allow_expired);
-            setReEnrollmentValidationCAs(reAuthSettings.client_certificate_settings.validation_cas.map(id => findCaById(id, availableCAsForSelection)).filter(Boolean) as CA[]);
-          }
-
-          if ((currentReAuthMode === 'External Webhook' || currentReAuthMode === 'Client Certificate + Webhook') && reAuthSettings.external_webhook_settings) {
-            const webhookSettings = reAuthSettings.external_webhook_settings;
-            setReWebhookName(webhookSettings.name || '');
-            setReWebhookUrl(webhookSettings.url || '');
-            setReWebhookMethod(webhookSettings.method || 'POST');
-            setReWebhookValidateServerCert(webhookSettings.config.validate_server_cert ?? false);
-            setReWebhookLogLevel(webhookSettings.config.log_level || 'Info');
-
-            const apiWebhookAuthMode = webhookSettings.config.auth_mode;
-            let uiWebhookAuthMode = 'No Auth';
-            if (apiWebhookAuthMode === 'OIDC') uiWebhookAuthMode = 'OIDC';
-            if (apiWebhookAuthMode === 'API_KEY') uiWebhookAuthMode = 'API Key';
-            setReWebhookAuthMode(uiWebhookAuthMode);
-
-            if (uiWebhookAuthMode === 'API Key' && webhookSettings.config.apikey) {
-              setReWebhookApiKey(webhookSettings.config.apikey.key || '');
-              setReWebhookApiKeyHeader(webhookSettings.config.apikey.header || 'X-API-Key');
-            } else if (uiWebhookAuthMode === 'OIDC' && webhookSettings.config.oidc) {
-              setReOidcClientId(webhookSettings.config.oidc.client_id || '');
-              setReOidcClientSecret(webhookSettings.config.oidc.client_secret || '');
-              setReOidcWellKnownUrl(webhookSettings.config.oidc.well_known || '');
-            }
-          }
-        }
+        const hydratedReEnrollmentAuth = hydrateRaAuthFormValuesFromApi(reenrollment_settings.est_rfc7030_settings);
+        setReEnrollmentAuthConfig(hydratedReEnrollmentAuth);
+        setReEnrollmentValidationCAs(hydratedReEnrollmentAuth.validationCaIds.map(id => findCaById(id, availableCAsForSelection)).filter(Boolean) as CA[]);
 
         setEnableKeyGeneration(server_keygen_settings.enabled);
         if (server_keygen_settings.enabled && server_keygen_settings.key) {
@@ -352,84 +256,14 @@ export default function CreateOrEditRegistrationAuthorityPage() {
         return;
     }
     const protocolMapping: { [key: string]: string } = { 'EST': 'EST_RFC7030', 'None': '' };
-    const authModeMapping = { 'Client Certificate': 'CLIENT_CERTIFICATE', 'External Webhook': 'EXTERNAL_WEBHOOK', 'No Auth': 'NONE', 'Client Certificate + Webhook': 'CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK' };
-    
-    const estSettings: any = {
-        auth_mode: authModeMapping[authMode as keyof typeof authModeMapping],
-    };
-
-    if (authMode === 'Client Certificate' || authMode === 'Client Certificate + Webhook') {
-        estSettings.client_certificate_settings = {
-            chain_level_validation: chainValidationLevel,
-            validation_cas: validationCAs.map(ca => ca.id),
-            allow_expired: allowExpiredAuth,
-        };
-    }
-    if (authMode === 'External Webhook' || authMode === 'Client Certificate + Webhook') {
-        const webhookAuthModeMapping: { [key: string]: string } = { 'No Auth': 'NO_AUTH', 'OIDC': 'OIDC', 'API Key': 'API_KEY' };
-        const webhookConfig: any = {
-            validate_server_cert: webhookValidateServerCert,
-            log_level: webhookLogLevel,
-            auth_mode: webhookAuthModeMapping[webhookAuthMode],
-        };
-        if (webhookAuthMode === 'API Key') {
-            webhookConfig.apikey = {
-                key: webhookApiKey,
-                header: webhookApiKeyHeader,
-            };
-        } else if (webhookAuthMode === 'OIDC') {
-            webhookConfig.oidc = {
-                client_id: oidcClientId,
-                client_secret: oidcClientSecret,
-                well_known: oidcWellKnownUrl,
-            };
-        }
-        estSettings.external_webhook_settings = {
-            name: webhookName,
-            url: webhookUrl,
-            method: webhookMethod,
-            config: webhookConfig,
-        };
-    }
-
-      const reEnrollmentEstSettings: any = {
-        auth_mode: authModeMapping[reEnrollmentAuthMode as keyof typeof authModeMapping],
-      };
-
-      if (reEnrollmentAuthMode === 'Client Certificate' || reEnrollmentAuthMode === 'Client Certificate + Webhook') {
-        reEnrollmentEstSettings.client_certificate_settings = {
-          chain_level_validation: reChainValidationLevel,
-          validation_cas: reEnrollmentValidationCAs.map(ca => ca.id),
-          allow_expired: allowExpiredReAuth,
-        };
-      }
-
-      if (reEnrollmentAuthMode === 'External Webhook' || reEnrollmentAuthMode === 'Client Certificate + Webhook') {
-        const webhookAuthModeMapping: { [key: string]: string } = { 'No Auth': 'NO_AUTH', 'OIDC': 'OIDC', 'API Key': 'API_KEY' };
-        const reWebhookConfig: any = {
-          validate_server_cert: reWebhookValidateServerCert,
-          log_level: reWebhookLogLevel,
-          auth_mode: webhookAuthModeMapping[reWebhookAuthMode],
-        };
-        if (reWebhookAuthMode === 'API Key') {
-          reWebhookConfig.apikey = {
-            key: reWebhookApiKey,
-            header: reWebhookApiKeyHeader,
-          };
-        } else if (reWebhookAuthMode === 'OIDC') {
-          reWebhookConfig.oidc = {
-            client_id: reOidcClientId,
-            client_secret: reOidcClientSecret,
-            well_known: reOidcWellKnownUrl,
-          };
-        }
-        reEnrollmentEstSettings.external_webhook_settings = {
-          name: reWebhookName,
-          url: reWebhookUrl,
-          method: reWebhookMethod,
-          config: reWebhookConfig,
-        };
-      }
+    const estSettings = buildApiRaEstSettingsFromForm({
+      ...enrollmentAuthConfig,
+      validationCaIds: validationCAs.map((ca) => ca.id),
+    });
+    const reEnrollmentEstSettings = buildApiRaEstSettingsFromForm({
+      ...reEnrollmentAuthConfig,
+      validationCaIds: reEnrollmentValidationCAs.map((ca) => ca.id),
+    });
 
 
     let keySettings;
@@ -439,9 +273,10 @@ export default function CreateOrEditRegistrationAuthorityPage() {
             : Number.parseInt(serverKeygenSpec, 10);
         keySettings = { type: serverKeygenType, bits };
     }
+    const resolvedRaId = isEditMode ? (raIdFromQuery ?? '') : raId.trim();
     const payload: RaCreationPayload = {
       name: raName.trim(),
-      id: isEditMode ? raIdFromQuery! : raId.trim(),
+      id: resolvedRaId,
       metadata: raData?.metadata || {},
       settings: {
         enrollment_settings: {
@@ -497,12 +332,20 @@ export default function CreateOrEditRegistrationAuthorityPage() {
   const handleAddValidationCa = (ca: CA) => {
     if (!validationCAs.some(vca => vca.id === ca.id)) {
         setValidationCAs(prev => [...prev, ca]);
+        setEnrollmentAuthConfig((prev) => ({
+          ...prev,
+          validationCaIds: [...prev.validationCaIds, ca.id],
+        }));
     }
     setIsValidationCaModalOpen(false);
   }
 
   const handleRemoveValidationCa = (caId: string) => {
     setValidationCAs(prev => prev.filter(vca => vca.id !== caId));
+    setEnrollmentAuthConfig((prev) => ({
+      ...prev,
+      validationCaIds: prev.validationCaIds.filter((id) => id !== caId),
+    }));
   }
 
   const handleAddAdditionalValidationCa = (ca: CA) => {
@@ -519,12 +362,20 @@ export default function CreateOrEditRegistrationAuthorityPage() {
   const handleAddReEnrollmentValidationCa = (ca: CA) => {
     if (!reEnrollmentValidationCAs.some(vca => vca.id === ca.id)) {
       setReEnrollmentValidationCAs(prev => [...prev, ca]);
+      setReEnrollmentAuthConfig((prev) => ({
+        ...prev,
+        validationCaIds: [...prev.validationCaIds, ca.id],
+      }));
     }
     setIsReEnrollmentValidationCaModalOpen(false);
   }
 
   const handleRemoveReEnrollmentValidationCa = (caId: string) => {
     setReEnrollmentValidationCAs(prev => prev.filter(vca => vca.id !== caId));
+    setReEnrollmentAuthConfig((prev) => ({
+      ...prev,
+      validationCaIds: prev.validationCaIds.filter((id) => id !== caId),
+    }));
   }
 
   const handleAddManagedCa = (ca: CA) => {
@@ -543,10 +394,21 @@ export default function CreateOrEditRegistrationAuthorityPage() {
 
 
   const PageIcon = isEditMode ? Edit : PlusCircle;
+  let enrollmentCaButtonLabel: string | null = null;
+  if (!isLoadingDependencies) {
+    enrollmentCaButtonLabel = enrollmentCa ? enrollmentCa.name : "Select Enrollment CA...";
+  }
+
+  let submitButtonLabel = 'Create RA';
+  if (isSubmitting) {
+    submitButtonLabel = 'Saving...';
+  } else if (isEditMode) {
+    submitButtonLabel = 'Save Changes';
+  }
   const heroBadges = [
     registrationMode,
     protocol,
-    authMode,
+    enrollmentAuthConfig.authMode,
   ];
   const summaryCards = [
     {
@@ -698,10 +560,10 @@ export default function CreateOrEditRegistrationAuthorityPage() {
                   <div className="pt-2">
                   <Label htmlFor="deviceIconButton">Device Icon</Label>
                   <Button id="deviceIconButton" type="button" variant="outline" onClick={() => setIsDeviceIconModalOpen(true)} className="w-full justify-start text-left font-normal flex items-center gap-2 mt-1">
-                      {getLucideIconByName(selectedDeviceIconName) ? (
+                      {SelectedDeviceIcon ? (
                       <div className="flex items-center gap-2">
                           <div className="p-1 rounded-sm flex items-center justify-center" style={{ backgroundColor: selectedDeviceIconBgColor }}>
-                          {React.createElement(getLucideIconByName(selectedDeviceIconName)!, { className: "h-5 w-5", style: { color: selectedDeviceIconColor } })}
+                        <SelectedDeviceIcon className="h-5 w-5" style={{ color: selectedDeviceIconColor }} />
                           </div>
                           {selectedDeviceIconName}
                       </div>
@@ -728,7 +590,7 @@ export default function CreateOrEditRegistrationAuthorityPage() {
                   </div>
               <div>
                 <Label htmlFor="enrollmentCa">Enrollment CA</Label>
-                <Button type="button" variant="outline" onClick={() => setIsEnrollmentCaModalOpen(true)} className="w-full justify-start text-left font-normal mt-1" disabled={isLoadingDependencies}>{isLoadingDependencies ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : enrollmentCa ? enrollmentCa.name : "Select Enrollment CA..."}</Button>
+                    <Button type="button" variant="outline" onClick={() => setIsEnrollmentCaModalOpen(true)} className="w-full justify-start text-left font-normal mt-1" disabled={isLoadingDependencies}>{isLoadingDependencies ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : enrollmentCaButtonLabel}</Button>
                 {enrollmentCa && 
                   <div className="mt-2 space-y-3">
                     <CaVisualizerCard ca={enrollmentCa} className="shadow-none border-border" allCryptoEngines={allCryptoEngines} />
@@ -801,129 +663,18 @@ export default function CreateOrEditRegistrationAuthorityPage() {
                 </div>
                 <Switch id="verifyCsrSignature" checked={verifyCsrSignature} onCheckedChange={setVerifyCsrSignature} />
               </div>
-              <div><Label htmlFor="authMode">Authentication Mode</Label><Select value={authMode} onValueChange={setAuthMode}><SelectTrigger id="authMode" className="mt-1"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="Client Certificate">Client Certificate</SelectItem><SelectItem value="External Webhook">External Webhook</SelectItem><SelectItem value="Client Certificate + Webhook">Client Certificate + Webhook</SelectItem><SelectItem value="No Auth">No Auth</SelectItem></SelectContent></Select></div>
-              
-              {(authMode === 'Client Certificate' || authMode === 'Client Certificate + Webhook') && (
-                  <div className="space-y-4 pt-2 border-t mt-4">
-                      <h4 className="font-medium text-md text-muted-foreground pt-2">Client Certificate Auth Settings</h4>
-                      <div>
-                        <Label>Validation CAs</Label>
-                        <div className="mt-2 space-y-2">
-                            {validationCAs.length > 0 ? (
-                                validationCAs.map(ca => (
-                                    <div key={ca.id} className="flex items-center gap-2 group">
-                                        <CaVisualizerCard ca={ca} allCryptoEngines={allCryptoEngines} className="flex-grow shadow-none border-border" />
-                                        <Button type="button" variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-destructive opacity-50 group-hover:opacity-100" onClick={() => handleRemoveValidationCa(ca.id)}>
-                                            <X className="h-4 w-4" />
-                                        </Button>
-                                    </div>
-                                ))
-                            ) : (
-                                <p className="text-sm text-muted-foreground italic text-center p-2">No validation CAs selected.</p>
-                            )}
-                        </div>
-                        <Button type="button" variant="outline" size="sm" onClick={() => setIsValidationCaModalOpen(true)} className="mt-2">
-                           <PlusCircle className="mr-2 h-4 w-4" /> Add Validation CA
-                        </Button>
-                      </div>
-                      <div className="flex items-center space-x-2 pt-2"><Switch id="allowExpiredAuth" checked={allowExpiredAuth} onCheckedChange={setAllowExpiredAuth} /><Label htmlFor="allowExpiredAuth">Allow Authenticating Expired Certificates</Label></div>
-                      <div><Label htmlFor="chainValidationLevel" className="flex items-center">Chain Validation Level<TooltipProvider><Tooltip><TooltipTrigger asChild><HelpCircle className="ml-1 h-4 w-4 text-muted-foreground cursor-help" /></TooltipTrigger><TooltipContent><p>-1 equals full chain validation.</p></TooltipContent></Tooltip></TooltipProvider></Label><Input id="chainValidationLevel" type="number" value={chainValidationLevel} onChange={(e) => setChainValidationLevel(Number.parseInt(e.target.value))} className="mt-1" /></div>
-                  </div>
-              )}
-
-              {(authMode === 'External Webhook' || authMode === 'Client Certificate + Webhook') && (
-                  <div className="space-y-4 pt-2 border-t mt-4">
-                      <h4 className="font-medium text-md text-muted-foreground pt-2">Webhook Settings</h4>
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                          <div>
-                              <Label htmlFor="webhookName">Webhook Name</Label>
-                              <Input id="webhookName" value={webhookName} onChange={(e) => setWebhookName(e.target.value)} placeholder="e.g., MyValidationFunc" className="mt-1" />
-                          </div>
-                          <div>
-                              <Label htmlFor="webhookUrl">Webhook URL</Label>
-                              <Input id="webhookUrl" value={webhookUrl} onChange={(e) => setWebhookUrl(e.target.value)} placeholder="http://localhost:8080/verify" className="mt-1" />
-                          </div>
-                      </div>
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                          <div>
-                              <Label htmlFor="webhookMethod">HTTP Method</Label>
-                              <Select value={webhookMethod} onValueChange={setWebhookMethod}>
-                                  <SelectTrigger id="webhookMethod" className="mt-1"><SelectValue /></SelectTrigger>
-                                  <SelectContent>
-                                      <SelectItem value="POST">POST</SelectItem>
-                                      <SelectItem value="PUT">PUT</SelectItem>
-                                  </SelectContent>
-                              </Select>
-                          </div>
-                          <div>
-                              <Label htmlFor="webhookLogLevel">Log Level</Label>
-                              <Select value={webhookLogLevel} onValueChange={setWebhookLogLevel}>
-                                  <SelectTrigger id="webhookLogLevel" className="mt-1"><SelectValue /></SelectTrigger>
-                                  <SelectContent>
-                                      <SelectItem value="Info">Info</SelectItem>
-                                      <SelectItem value="Debug">Debug</SelectItem>
-                                      <SelectItem value="Warn">Warn</SelectItem>
-                                      <SelectItem value="Error">Error</SelectItem>
-                                  </SelectContent>
-                              </Select>
-                          </div>
-                      </div>
-                      <div className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm bg-background">
-                          <div className="space-y-0.5">
-                              <Label htmlFor="webhookValidateServerCert" className="flex items-center">
-                                  <Server className="mr-2 h-4 w-4 text-muted-foreground" />
-                                  Validate Server Certificate
-                              </Label>
-                              <p className="text-sm text-muted-foreground">
-                                  Verify the TLS certificate of the webhook endpoint.
-                              </p>
-                          </div>
-                          <Switch id="webhookValidateServerCert" checked={webhookValidateServerCert} onCheckedChange={setWebhookValidateServerCert} />
-                      </div>
-                      <div>
-                          <div>
-                              <Label htmlFor="webhookAuthMode">Auth Mode</Label>
-                              <Select value={webhookAuthMode} onValueChange={setWebhookAuthMode}>
-                                  <SelectTrigger id="webhookAuthMode" className="mt-1"><SelectValue /></SelectTrigger>
-                                  <SelectContent>
-                                      <SelectItem value="No Auth">No Auth</SelectItem>
-                                      <SelectItem value="OIDC">OIDC</SelectItem>
-                                      <SelectItem value="API Key">API Key</SelectItem>
-                                  </SelectContent>
-                              </Select>
-                          </div>
-                      </div>
-                      {webhookAuthMode === 'API Key' && (
-                          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                              <div>
-                                  <Label htmlFor="webhookApiKey">API Key</Label>
-                                  <Input id="webhookApiKey" type="password" value={webhookApiKey} onChange={e => setWebhookApiKey(e.target.value)} placeholder="Enter API Key" className="mt-1"/>
-                              </div>
-                              <div>
-                                  <Label htmlFor="webhookApiKeyHeader">Header Name</Label>
-                                  <Input id="webhookApiKeyHeader" value={webhookApiKeyHeader} onChange={e => setWebhookApiKeyHeader(e.target.value)} placeholder="X-API-Key" className="mt-1"/>
-                              </div>
-                          </div>
-                      )}
-                      {webhookAuthMode === 'OIDC' && (
-                          <div className="space-y-4 pt-2 border-t mt-4">
-                              <h5 className="font-medium text-sm text-muted-foreground pt-2">OIDC Settings</h5>
-                              <div>
-                                  <Label htmlFor="oidcClientId">Client ID</Label>
-                                  <Input id="oidcClientId" value={oidcClientId} onChange={e => setOidcClientId(e.target.value)} placeholder="Enter OIDC Client ID" className="mt-1"/>
-                              </div>
-                              <div>
-                                  <Label htmlFor="oidcClientSecret">Client Secret</Label>
-                                  <Input id="oidcClientSecret" type="password" value={oidcClientSecret} onChange={e => setOidcClientSecret(e.target.value)} placeholder="Enter OIDC Client Secret" className="mt-1"/>
-                              </div>
-                              <div>
-                                  <Label htmlFor="oidcWellKnownUrl">Well-Known URL</Label>
-                                  <Input id="oidcWellKnownUrl" value={oidcWellKnownUrl} onChange={e => setOidcWellKnownUrl(e.target.value)} placeholder="https://your-issuer.com/.well-known/openid-configuration" className="mt-1"/>
-                              </div>
-                          </div>
-                      )}
-                  </div>
-              )}
+                <RaAuthConfigurationSection
+                inputIdPrefix="enrollment"
+                authModeLabel="Authentication Mode"
+                clientCertTitle="Client Certificate Auth Settings"
+                webhookTitle="Webhook Settings"
+                values={enrollmentAuthConfig}
+                validationCAs={validationCAs}
+                allCryptoEngines={allCryptoEngines}
+                onValuesChange={(patch) => setEnrollmentAuthConfig((prev) => ({ ...prev, ...patch }))}
+                onAddValidationCaClick={() => setIsValidationCaModalOpen(true)}
+                onRemoveValidationCa={handleRemoveValidationCa}
+                />
               </SettingsCard>
 
               <SettingsCard
@@ -980,147 +731,18 @@ export default function CreateOrEditRegistrationAuthorityPage() {
                     </Button>
                   </div>
 
-                  <div>
-                    <Label htmlFor="reEnrollmentAuthMode">Re-Enrollment Authentication Mode</Label>
-                    <Select value={reEnrollmentAuthMode} onValueChange={setReEnrollmentAuthMode}>
-                      <SelectTrigger id="reEnrollmentAuthMode" className="mt-1"><SelectValue /></SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="Client Certificate">Client Certificate</SelectItem>
-                        <SelectItem value="External Webhook">External Webhook</SelectItem>
-                        <SelectItem value="Client Certificate + Webhook">Client Certificate + Webhook</SelectItem>
-                        <SelectItem value="No Auth">No Auth</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-
-                  {(reEnrollmentAuthMode === 'Client Certificate' || reEnrollmentAuthMode === 'Client Certificate + Webhook') && (
-                    <div className="space-y-4 pt-2 border-t mt-4">
-                      <h4 className="font-medium text-md text-muted-foreground pt-2">Client Certificate Re-Enrollment Auth Settings</h4>
-                      <div>
-                        <Label htmlFor="reEnrollmentValidationCAs">Validation CAs</Label>
-                        <div className="mt-2 space-y-2">
-                          {reEnrollmentValidationCAs.length > 0 ? (
-                            reEnrollmentValidationCAs.map(ca => (
-                              <div key={ca.id} className="flex items-center gap-2 group">
-                                <CaVisualizerCard ca={ca} allCryptoEngines={allCryptoEngines} className="flex-grow shadow-none border-border" />
-                                <Button type="button" variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-destructive opacity-50 group-hover:opacity-100" onClick={() => handleRemoveReEnrollmentValidationCa(ca.id)}>
-                                  <X className="h-4 w-4" />
-                                </Button>
-                              </div>
-                            ))
-                          ) : (
-                            <p className="text-sm text-muted-foreground italic text-center p-2">No validation CAs selected.</p>
-                          )}
-                        </div>
-                        <Button type="button" variant="outline" size="sm" onClick={() => setIsReEnrollmentValidationCaModalOpen(true)} className="mt-2">
-                          <PlusCircle className="mr-2 h-4 w-4" /> Add Validation CA
-                        </Button>
-                      </div>
-                      <div className="flex items-center space-x-2 pt-2">
-                        <Switch id="allowExpiredReAuth" checked={allowExpiredReAuth} onCheckedChange={setAllowExpiredReAuth} />
-                        <Label htmlFor="allowExpiredReAuth">Allow Authenticating Expired Certificates</Label>
-                      </div>
-                      <div>
-                        <Label htmlFor="reChainValidationLevel" className="flex items-center">
-                          Chain Validation Level
-                          <TooltipProvider><Tooltip><TooltipTrigger asChild><HelpCircle className="ml-1 h-4 w-4 text-muted-foreground cursor-help" /></TooltipTrigger><TooltipContent><p>-1 equals full chain validation.</p></TooltipContent></Tooltip></TooltipProvider>
-                        </Label>
-                        <Input id="reChainValidationLevel" type="number" value={reChainValidationLevel} onChange={(e) => setReChainValidationLevel(Number.parseInt(e.target.value))} className="mt-1" />
-                      </div>
-                    </div>
-                  )}
-
-                  {(reEnrollmentAuthMode === 'External Webhook' || reEnrollmentAuthMode === 'Client Certificate + Webhook') && (
-                    <div className="space-y-4 pt-2 border-t mt-4">
-                      <h4 className="font-medium text-md text-muted-foreground pt-2">Webhook Re-Enrollment Auth Settings</h4>
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        <div>
-                          <Label htmlFor="reWebhookName">Webhook Name</Label>
-                          <Input id="reWebhookName" value={reWebhookName} onChange={(e) => setReWebhookName(e.target.value)} placeholder="e.g., ReEnrollmentValidationFunc" className="mt-1" />
-                        </div>
-                        <div>
-                          <Label htmlFor="reWebhookUrl">Webhook URL</Label>
-                          <Input id="reWebhookUrl" value={reWebhookUrl} onChange={(e) => setReWebhookUrl(e.target.value)} placeholder="http://localhost:8080/verify-reenrollment" className="mt-1" />
-                        </div>
-                      </div>
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        <div>
-                          <Label htmlFor="reWebhookMethod">HTTP Method</Label>
-                          <Select value={reWebhookMethod} onValueChange={setReWebhookMethod}>
-                            <SelectTrigger id="reWebhookMethod" className="mt-1"><SelectValue /></SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="POST">POST</SelectItem>
-                              <SelectItem value="PUT">PUT</SelectItem>
-                            </SelectContent>
-                          </Select>
-                        </div>
-                        <div>
-                          <Label htmlFor="reWebhookLogLevel">Log Level</Label>
-                          <Select value={reWebhookLogLevel} onValueChange={setReWebhookLogLevel}>
-                            <SelectTrigger id="reWebhookLogLevel" className="mt-1"><SelectValue /></SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="Info">Info</SelectItem>
-                              <SelectItem value="Debug">Debug</SelectItem>
-                              <SelectItem value="Warn">Warn</SelectItem>
-                              <SelectItem value="Error">Error</SelectItem>
-                            </SelectContent>
-                          </Select>
-                        </div>
-                      </div>
-                      <div className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm bg-background">
-                        <div className="space-y-0.5">
-                          <Label htmlFor="reWebhookValidateServerCert" className="flex items-center">
-                            <Server className="mr-2 h-4 w-4 text-muted-foreground" />
-                            Validate Server Certificate
-                          </Label>
-                          <p className="text-sm text-muted-foreground">
-                            Verify the TLS certificate of the webhook endpoint.
-                          </p>
-                        </div>
-                        <Switch id="reWebhookValidateServerCert" checked={reWebhookValidateServerCert} onCheckedChange={setReWebhookValidateServerCert} />
-                      </div>
-                      <div>
-                        <Label htmlFor="reWebhookAuthMode">Auth Mode</Label>
-                        <Select value={reWebhookAuthMode} onValueChange={setReWebhookAuthMode}>
-                          <SelectTrigger id="reWebhookAuthMode" className="mt-1"><SelectValue /></SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="No Auth">No Auth</SelectItem>
-                            <SelectItem value="OIDC">OIDC</SelectItem>
-                            <SelectItem value="API Key">API Key</SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </div>
-                      {reWebhookAuthMode === 'API Key' && (
-                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                          <div>
-                            <Label htmlFor="reWebhookApiKey">API Key</Label>
-                            <Input id="reWebhookApiKey" type="password" value={reWebhookApiKey} onChange={e => setReWebhookApiKey(e.target.value)} placeholder="Enter API Key" className="mt-1"/>
-                          </div>
-                          <div>
-                            <Label htmlFor="reWebhookApiKeyHeader">Header Name</Label>
-                            <Input id="reWebhookApiKeyHeader" value={reWebhookApiKeyHeader} onChange={e => setReWebhookApiKeyHeader(e.target.value)} placeholder="X-API-Key" className="mt-1"/>
-                          </div>
-                        </div>
-                      )}
-                      {reWebhookAuthMode === 'OIDC' && (
-                        <div className="space-y-4 pt-2 border-t mt-4">
-                          <h5 className="font-medium text-sm text-muted-foreground pt-2">OIDC Settings</h5>
-                          <div>
-                            <Label htmlFor="reOidcClientId">Client ID</Label>
-                            <Input id="reOidcClientId" value={reOidcClientId} onChange={e => setReOidcClientId(e.target.value)} placeholder="Enter OIDC Client ID" className="mt-1"/>
-                          </div>
-                          <div>
-                            <Label htmlFor="reOidcClientSecret">Client Secret</Label>
-                            <Input id="reOidcClientSecret" type="password" value={reOidcClientSecret} onChange={e => setReOidcClientSecret(e.target.value)} placeholder="Enter OIDC Client Secret" className="mt-1"/>
-                          </div>
-                          <div>
-                            <Label htmlFor="reOidcWellKnownUrl">Well-Known URL</Label>
-                            <Input id="reOidcWellKnownUrl" value={reOidcWellKnownUrl} onChange={e => setReOidcWellKnownUrl(e.target.value)} placeholder="https://your-issuer.com/.well-known/openid-configuration" className="mt-1"/>
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  )}
+                  <RaAuthConfigurationSection
+                    inputIdPrefix="reenrollment"
+                    authModeLabel="Re-Enrollment Authentication Mode"
+                    clientCertTitle="Client Certificate Re-Enrollment Auth Settings"
+                    webhookTitle="Webhook Re-Enrollment Auth Settings"
+                    values={reEnrollmentAuthConfig}
+                    validationCAs={reEnrollmentValidationCAs}
+                    allCryptoEngines={allCryptoEngines}
+                    onValuesChange={(patch) => setReEnrollmentAuthConfig((prev) => ({ ...prev, ...patch }))}
+                    onAddValidationCaClick={() => setIsReEnrollmentValidationCaModalOpen(true)}
+                    onRemoveValidationCa={handleRemoveReEnrollmentValidationCa}
+                  />
               </SettingsCard>
 
               <SettingsCard
@@ -1196,7 +818,7 @@ export default function CreateOrEditRegistrationAuthorityPage() {
                   <Button type="button" variant="outline" onClick={() => router.back()}>Cancel</Button>
                   <Button type="submit" disabled={isSubmitting}>
                       {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin"/> : <PlusCircle className="mr-2 h-4 w-4" />}
-                      {isSubmitting ? 'Saving...' : isEditMode ? 'Save Changes' : 'Create RA'}
+                    {submitButtonLabel}
                   </Button>
               </div>
       </form>

--- a/src/components/ra/RaAuthConfigurationSection.tsx
+++ b/src/components/ra/RaAuthConfigurationSection.tsx
@@ -1,0 +1,206 @@
+import React from 'react';
+import { HelpCircle, PlusCircle, Server, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { CaVisualizerCard } from '@/components/CaVisualizerCard';
+import type { CA } from '@/lib/ca-data';
+import type { ApiCryptoEngine } from '@/types/crypto-engine';
+import type { RaAuthFormValues, UiRaAuthMode, UiWebhookAuthMode } from '@/types/ra-auth';
+
+type RaAuthConfigField = keyof RaAuthFormValues;
+
+interface RaAuthConfigurationSectionProps {
+  inputIdPrefix: string;
+  authModeLabel: string;
+  clientCertTitle: string;
+  webhookTitle: string;
+  values: RaAuthFormValues;
+  validationCAs: CA[];
+  allCryptoEngines: ApiCryptoEngine[];
+  onValuesChange: (patch: Partial<RaAuthFormValues>) => void;
+  onAddValidationCaClick: () => void;
+  onRemoveValidationCa: (caId: string) => void;
+}
+
+const authModeOptions: UiRaAuthMode[] = [
+  'Client Certificate',
+  'External Webhook',
+  'Client Certificate + Webhook',
+  'No Auth',
+];
+
+const webhookAuthModeOptions: UiWebhookAuthMode[] = ['No Auth', 'OIDC', 'API Key'];
+
+export function RaAuthConfigurationSection({
+  inputIdPrefix,
+  authModeLabel,
+  clientCertTitle,
+  webhookTitle,
+  values,
+  validationCAs,
+  allCryptoEngines,
+  onValuesChange,
+  onAddValidationCaClick,
+  onRemoveValidationCa,
+}: Readonly<RaAuthConfigurationSectionProps>) {
+  const setField = <T extends RaAuthConfigField>(field: T, value: RaAuthFormValues[T]) => {
+    onValuesChange({ [field]: value });
+  };
+
+  const usesClientCert = values.authMode === 'Client Certificate' || values.authMode === 'Client Certificate + Webhook';
+  const usesWebhook = values.authMode === 'External Webhook' || values.authMode === 'Client Certificate + Webhook';
+
+  return (
+    <>
+      <div>
+        <Label htmlFor={`${inputIdPrefix}-auth-mode`}>{authModeLabel}</Label>
+        <Select value={values.authMode} onValueChange={(mode: UiRaAuthMode) => setField('authMode', mode)}>
+          <SelectTrigger id={`${inputIdPrefix}-auth-mode`} className="mt-1"><SelectValue /></SelectTrigger>
+          <SelectContent>
+            {authModeOptions.map((option) => (
+              <SelectItem key={option} value={option}>{option}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {usesClientCert && (
+        <div className="space-y-4 pt-2 border-t mt-4">
+          <h4 className="font-medium text-md text-muted-foreground pt-2">{clientCertTitle}</h4>
+          <div>
+            <Label htmlFor={`${inputIdPrefix}-validation-cas`}>Validation CAs</Label>
+            <div className="mt-2 space-y-2" id={`${inputIdPrefix}-validation-cas`}>
+              {validationCAs.length > 0 ? (
+                validationCAs.map((ca) => (
+                  <div key={ca.id} className="flex items-center gap-2 group">
+                    <CaVisualizerCard ca={ca} allCryptoEngines={allCryptoEngines} className="flex-grow shadow-none border-border" />
+                    <Button type="button" variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-destructive opacity-50 group-hover:opacity-100" onClick={() => onRemoveValidationCa(ca.id)}>
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ))
+              ) : (
+                <p className="text-sm text-muted-foreground italic text-center p-2">No validation CAs selected.</p>
+              )}
+            </div>
+            <Button type="button" variant="outline" size="sm" onClick={onAddValidationCaClick} className="mt-2">
+              <PlusCircle className="mr-2 h-4 w-4" /> Add Validation CA
+            </Button>
+          </div>
+          <div className="flex items-center space-x-2 pt-2">
+            <Switch id={`${inputIdPrefix}-allow-expired-auth`} checked={values.allowExpiredAuth} onCheckedChange={(checked) => setField('allowExpiredAuth', checked)} />
+            <Label htmlFor={`${inputIdPrefix}-allow-expired-auth`}>Allow Authenticating Expired Certificates</Label>
+          </div>
+          <div>
+            <Label htmlFor={`${inputIdPrefix}-chain-validation-level`} className="flex items-center">
+              Chain Validation Level
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild><HelpCircle className="ml-1 h-4 w-4 text-muted-foreground cursor-help" /></TooltipTrigger>
+                  <TooltipContent><p>-1 equals full chain validation.</p></TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </Label>
+            <Input id={`${inputIdPrefix}-chain-validation-level`} type="number" value={values.chainValidationLevel} onChange={(e) => setField('chainValidationLevel', Number.parseInt(e.target.value, 10))} className="mt-1" />
+          </div>
+        </div>
+      )}
+
+      {usesWebhook && (
+        <div className="space-y-4 pt-2 border-t mt-4">
+          <h4 className="font-medium text-md text-muted-foreground pt-2">{webhookTitle}</h4>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor={`${inputIdPrefix}-webhook-name`}>Webhook Name</Label>
+              <Input id={`${inputIdPrefix}-webhook-name`} value={values.webhookName} onChange={(e) => setField('webhookName', e.target.value)} placeholder="e.g., ValidationWebhook" className="mt-1" />
+            </div>
+            <div>
+              <Label htmlFor={`${inputIdPrefix}-webhook-url`}>Webhook URL</Label>
+              <Input id={`${inputIdPrefix}-webhook-url`} value={values.webhookUrl} onChange={(e) => setField('webhookUrl', e.target.value)} placeholder="http://localhost:8080/verify" className="mt-1" />
+            </div>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor={`${inputIdPrefix}-webhook-method`}>HTTP Method</Label>
+              <Select value={values.webhookMethod} onValueChange={(v: 'POST' | 'PUT') => setField('webhookMethod', v)}>
+                <SelectTrigger id={`${inputIdPrefix}-webhook-method`} className="mt-1"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="POST">POST</SelectItem>
+                  <SelectItem value="PUT">PUT</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label htmlFor={`${inputIdPrefix}-webhook-log-level`}>Log Level</Label>
+              <Select value={values.webhookLogLevel} onValueChange={(v: 'Info' | 'Debug' | 'Warn' | 'Error') => setField('webhookLogLevel', v)}>
+                <SelectTrigger id={`${inputIdPrefix}-webhook-log-level`} className="mt-1"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="Info">Info</SelectItem>
+                  <SelectItem value="Debug">Debug</SelectItem>
+                  <SelectItem value="Warn">Warn</SelectItem>
+                  <SelectItem value="Error">Error</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <div className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm bg-background">
+            <div className="space-y-0.5">
+              <Label htmlFor={`${inputIdPrefix}-webhook-validate-server-cert`} className="flex items-center">
+                <Server className="mr-2 h-4 w-4 text-muted-foreground" />
+                Validate Server Certificate
+              </Label>
+              <p className="text-sm text-muted-foreground">Verify the TLS certificate of the webhook endpoint.</p>
+            </div>
+            <Switch id={`${inputIdPrefix}-webhook-validate-server-cert`} checked={values.webhookValidateServerCert} onCheckedChange={(checked) => setField('webhookValidateServerCert', checked)} />
+          </div>
+          <div>
+            <Label htmlFor={`${inputIdPrefix}-webhook-auth-mode`}>Auth Mode</Label>
+            <Select value={values.webhookAuthMode} onValueChange={(v: UiWebhookAuthMode) => setField('webhookAuthMode', v)}>
+              <SelectTrigger id={`${inputIdPrefix}-webhook-auth-mode`} className="mt-1"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {webhookAuthModeOptions.map((option) => (
+                  <SelectItem key={option} value={option}>{option}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {values.webhookAuthMode === 'API Key' && (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor={`${inputIdPrefix}-webhook-api-key`}>API Key</Label>
+                <Input id={`${inputIdPrefix}-webhook-api-key`} type="password" value={values.webhookApiKey} onChange={(e) => setField('webhookApiKey', e.target.value)} placeholder="Enter API Key" className="mt-1" />
+              </div>
+              <div>
+                <Label htmlFor={`${inputIdPrefix}-webhook-api-key-header`}>Header Name</Label>
+                <Input id={`${inputIdPrefix}-webhook-api-key-header`} value={values.webhookApiKeyHeader} onChange={(e) => setField('webhookApiKeyHeader', e.target.value)} placeholder="X-API-Key" className="mt-1" />
+              </div>
+            </div>
+          )}
+
+          {values.webhookAuthMode === 'OIDC' && (
+            <div className="space-y-4 pt-2 border-t mt-4">
+              <h5 className="font-medium text-sm text-muted-foreground pt-2">OIDC Settings</h5>
+              <div>
+                <Label htmlFor={`${inputIdPrefix}-oidc-client-id`}>Client ID</Label>
+                <Input id={`${inputIdPrefix}-oidc-client-id`} value={values.oidcClientId} onChange={(e) => setField('oidcClientId', e.target.value)} placeholder="Enter OIDC Client ID" className="mt-1" />
+              </div>
+              <div>
+                <Label htmlFor={`${inputIdPrefix}-oidc-client-secret`}>Client Secret</Label>
+                <Input id={`${inputIdPrefix}-oidc-client-secret`} type="password" value={values.oidcClientSecret} onChange={(e) => setField('oidcClientSecret', e.target.value)} placeholder="Enter OIDC Client Secret" className="mt-1" />
+              </div>
+              <div>
+                <Label htmlFor={`${inputIdPrefix}-oidc-well-known-url`}>Well-Known URL</Label>
+                <Input id={`${inputIdPrefix}-oidc-well-known-url`} value={values.oidcWellKnownUrl} onChange={(e) => setField('oidcWellKnownUrl', e.target.value)} placeholder="https://your-issuer.com/.well-known/openid-configuration" className="mt-1" />
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/lib/dms-api.test.ts
+++ b/src/lib/dms-api.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect } from 'vitest'
 import { http, HttpResponse } from 'msw'
 import { server } from './test-utils/msw-server'
 import {
+  API_TO_UI_AUTH_MODE,
+  API_TO_UI_WEBHOOK_AUTH_MODE,
+  UI_TO_API_AUTH_MODE,
+  UI_TO_API_WEBHOOK_AUTH_MODE,
+  buildApiRaEstSettingsFromForm,
+  createDefaultRaAuthFormValues,
+  hydrateRaAuthFormValuesFromApi,
   fetchRegistrationAuthorities,
   fetchRaById,
   createOrUpdateRa,
@@ -13,6 +20,7 @@ import {
   deleteRaIntegration,
   type ApiRaListResponse,
   type ApiRaItem,
+  type ApiRaEstSettings,
   type RaCreationPayload,
 } from './dms-api'
 
@@ -532,8 +540,12 @@ describe('dms-api', () => {
               external_webhook_settings: {
                 name: 'combined-webhook',
                 url: 'https://auth.example.com/validate',
-                log_level: 'Info',
-                auth_mode: 'NO_AUTH',
+                method: 'POST',
+                config: {
+                  validate_server_cert: true,
+                  log_level: 'Info',
+                  auth_mode: 'NO_AUTH',
+                },
               },
             },
           },
@@ -585,10 +597,15 @@ describe('dms-api', () => {
               external_webhook_settings: {
                 name: 'my-webhook',
                 url: 'https://hooks.example.com/verify',
-                log_level: 'Info',
-                auth_mode: 'API_KEY',
-                api_key_auth: {
-                  key: 'super-secret-key',
+                method: 'POST',
+                config: {
+                  validate_server_cert: true,
+                  log_level: 'Info',
+                  auth_mode: 'API_KEY',
+                  apikey: {
+                    key: 'super-secret-key',
+                    header: 'X-API-Key',
+                  },
                 },
               },
             },
@@ -603,8 +620,8 @@ describe('dms-api', () => {
       expect(estSettings.client_certificate_settings).toBeDefined()
       expect(estSettings.client_certificate_settings.validation_cas).toEqual(['ca-1'])
       expect(estSettings.external_webhook_settings).toBeDefined()
-      expect(estSettings.external_webhook_settings.auth_mode).toBe('API_KEY')
-      expect(estSettings.external_webhook_settings.api_key_auth.key).toBe('super-secret-key')
+      expect(estSettings.external_webhook_settings.config.auth_mode).toBe('API_KEY')
+      expect(estSettings.external_webhook_settings.config.apikey.key).toBe('super-secret-key')
     })
 
     it('should create RA with combined auth mode and OIDC webhook', async () => {
@@ -635,12 +652,16 @@ describe('dms-api', () => {
               external_webhook_settings: {
                 name: 'oidc-webhook',
                 url: 'https://hooks.example.com/verify',
-                log_level: 'Debug',
-                auth_mode: 'OIDC',
-                oidc_auth: {
-                  client_id: 'my-client',
-                  client_secret: 'my-secret',
-                  well_known_url: 'https://idp.example.com/.well-known/openid-configuration',
+                method: 'POST',
+                config: {
+                  validate_server_cert: true,
+                  log_level: 'Debug',
+                  auth_mode: 'OIDC',
+                  oidc: {
+                    client_id: 'my-client',
+                    client_secret: 'my-secret',
+                    well_known: 'https://idp.example.com/.well-known/openid-configuration',
+                  },
                 },
               },
             },
@@ -653,8 +674,8 @@ describe('dms-api', () => {
       const estSettings = capturedBody.settings.enrollment_settings.est_rfc7030_settings
       expect(estSettings.auth_mode).toBe('CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK')
       expect(estSettings.client_certificate_settings.chain_level_validation).toBe(1)
-      expect(estSettings.external_webhook_settings.auth_mode).toBe('OIDC')
-      expect(estSettings.external_webhook_settings.oidc_auth.client_id).toBe('my-client')
+      expect(estSettings.external_webhook_settings.config.auth_mode).toBe('OIDC')
+      expect(estSettings.external_webhook_settings.config.oidc.client_id).toBe('my-client')
     })
 
     it('should handle createOrUpdateRa error without JSON response', async () => {
@@ -838,6 +859,90 @@ describe('dms-api', () => {
       await expect(
         deleteRaIntegration('ra-123', 'nonexistent')
       ).rejects.toThrow('Integration key not found')
+    })
+  })
+
+  describe('RA auth helper functions', () => {
+    it('should return expected default auth form values', () => {
+      const defaults = createDefaultRaAuthFormValues()
+
+      expect(defaults.authMode).toBe('Client Certificate')
+      expect(defaults.validationCaIds).toEqual([])
+      expect(defaults.allowExpiredAuth).toBe(true)
+      expect(defaults.chainValidationLevel).toBe(-1)
+      expect(defaults.webhookMethod).toBe('POST')
+      expect(defaults.webhookAuthMode).toBe('No Auth')
+      expect(defaults.webhookApiKeyHeader).toBe('X-API-Key')
+    })
+
+    it('should hydrate UI auth form values from EST API settings', () => {
+      const estSettings: ApiRaEstSettings = {
+        auth_mode: 'CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK',
+        client_certificate_settings: {
+          chain_level_validation: 2,
+          validation_cas: ['ca-1', 'ca-2'],
+          allow_expired: false,
+        },
+        external_webhook_settings: {
+          name: 'combined-webhook',
+          url: 'https://hooks.example.com/verify',
+          method: 'PUT',
+          config: {
+            validate_server_cert: false,
+            log_level: 'Debug',
+            auth_mode: 'OIDC',
+            oidc: {
+              client_id: 'client-id',
+              client_secret: 'secret',
+              well_known: 'https://idp.example.com/.well-known/openid-configuration',
+            },
+          },
+        },
+      }
+
+      const hydrated = hydrateRaAuthFormValuesFromApi(estSettings)
+
+      expect(hydrated.authMode).toBe('Client Certificate + Webhook')
+      expect(hydrated.validationCaIds).toEqual(['ca-1', 'ca-2'])
+      expect(hydrated.allowExpiredAuth).toBe(false)
+      expect(hydrated.chainValidationLevel).toBe(2)
+      expect(hydrated.webhookName).toBe('combined-webhook')
+      expect(hydrated.webhookMethod).toBe('PUT')
+      expect(hydrated.webhookValidateServerCert).toBe(false)
+      expect(hydrated.webhookAuthMode).toBe('OIDC')
+      expect(hydrated.oidcClientId).toBe('client-id')
+    })
+
+    it('should build EST API settings from UI form values for API key webhook auth', () => {
+      const formValues = {
+        ...createDefaultRaAuthFormValues(),
+        authMode: 'External Webhook',
+        webhookName: 'api-key-webhook',
+        webhookUrl: 'https://hooks.example.com/verify',
+        webhookMethod: 'POST',
+        webhookValidateServerCert: true,
+        webhookLogLevel: 'Warn',
+        webhookAuthMode: 'API Key',
+        webhookApiKey: 'my-secret-key',
+        webhookApiKeyHeader: 'X-Custom-Api-Key',
+      } as const
+
+      const built = buildApiRaEstSettingsFromForm(formValues)
+
+      expect(built.auth_mode).toBe('EXTERNAL_WEBHOOK')
+      expect(built.client_certificate_settings).toBeUndefined()
+      expect(built.external_webhook_settings?.name).toBe('api-key-webhook')
+      expect(built.external_webhook_settings?.config.auth_mode).toBe('API_KEY')
+      expect(built.external_webhook_settings?.config.apikey?.key).toBe('my-secret-key')
+      expect(built.external_webhook_settings?.config.apikey?.header).toBe('X-Custom-Api-Key')
+      expect(built.external_webhook_settings?.config.log_level).toBe('Warn')
+    })
+
+    it('should map UI/API auth mode constants in both directions', () => {
+      expect(UI_TO_API_AUTH_MODE['Client Certificate']).toBe('CLIENT_CERTIFICATE')
+      expect(API_TO_UI_AUTH_MODE.CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK).toBe('Client Certificate + Webhook')
+      expect(UI_TO_API_WEBHOOK_AUTH_MODE['API Key']).toBe('API_KEY')
+      expect(API_TO_UI_WEBHOOK_AUTH_MODE.NO_AUTH).toBe('No Auth')
     })
   })
 })

--- a/src/lib/dms-api.ts
+++ b/src/lib/dms-api.ts
@@ -62,6 +62,7 @@ export interface ApiRaSettings {
         preventive_delta: string;
         reenrollment_delta: string;
         additional_validation_cas: string[];
+        est_rfc7030_settings?: ApiRaEstSettings;
     };
     server_keygen_settings: {
         enabled: boolean;

--- a/src/lib/dms-api.ts
+++ b/src/lib/dms-api.ts
@@ -3,6 +3,33 @@
 
 import { get_DMS_MANAGER_API_BASE_URL, handleApiError } from './api-domains';
 import { apiFetch } from './api-client';
+import type { RaAuthFormValues, UiRaAuthMode, UiWebhookAuthMode } from '../types/ra-auth';
+
+export const UI_TO_API_AUTH_MODE: Record<UiRaAuthMode, string> = {
+    'Client Certificate': 'CLIENT_CERTIFICATE',
+    'External Webhook': 'EXTERNAL_WEBHOOK',
+    'No Auth': 'NONE',
+    'Client Certificate + Webhook': 'CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK',
+};
+
+export const API_TO_UI_AUTH_MODE: Record<string, UiRaAuthMode> = {
+    CLIENT_CERTIFICATE: 'Client Certificate',
+    EXTERNAL_WEBHOOK: 'External Webhook',
+    NONE: 'No Auth',
+    CLIENT_CERTIFICATE_AND_EXTERNAL_WEBHOOK: 'Client Certificate + Webhook',
+};
+
+export const UI_TO_API_WEBHOOK_AUTH_MODE: Record<UiWebhookAuthMode, string> = {
+    'No Auth': 'NO_AUTH',
+    OIDC: 'OIDC',
+    'API Key': 'API_KEY',
+};
+
+export const API_TO_UI_WEBHOOK_AUTH_MODE: Record<string, UiWebhookAuthMode> = {
+    NO_AUTH: 'No Auth',
+    OIDC: 'OIDC',
+    API_KEY: 'API Key',
+};
 
 // --- Interfaces ---
 
@@ -93,6 +120,101 @@ export interface RaCreationPayload {
     id: string;
     metadata: Record<string, any>;
     settings: ApiRaSettings;
+}
+
+export function createDefaultRaAuthFormValues(): RaAuthFormValues {
+    return {
+        authMode: 'Client Certificate',
+        validationCaIds: [],
+        allowExpiredAuth: true,
+        chainValidationLevel: -1,
+        webhookName: '',
+        webhookUrl: '',
+        webhookMethod: 'POST',
+        webhookValidateServerCert: true,
+        webhookLogLevel: 'Info',
+        webhookAuthMode: 'No Auth',
+        webhookApiKey: '',
+        webhookApiKeyHeader: 'X-API-Key',
+        oidcClientId: '',
+        oidcClientSecret: '',
+        oidcWellKnownUrl: '',
+    };
+}
+
+export function hydrateRaAuthFormValuesFromApi(estSettings?: ApiRaEstSettings): RaAuthFormValues {
+    const defaults = createDefaultRaAuthFormValues();
+    if (!estSettings) {
+        return defaults;
+    }
+
+    const authMode = API_TO_UI_AUTH_MODE[estSettings.auth_mode] || defaults.authMode;
+    const clientCert = estSettings.client_certificate_settings;
+    const webhook = estSettings.external_webhook_settings;
+    const webhookAuthMode = API_TO_UI_WEBHOOK_AUTH_MODE[webhook?.config.auth_mode || 'NO_AUTH'] || defaults.webhookAuthMode;
+
+    return {
+        ...defaults,
+        authMode,
+        validationCaIds: clientCert?.validation_cas || [],
+        allowExpiredAuth: clientCert?.allow_expired ?? defaults.allowExpiredAuth,
+        chainValidationLevel: clientCert?.chain_level_validation ?? defaults.chainValidationLevel,
+        webhookName: webhook?.name || defaults.webhookName,
+        webhookUrl: webhook?.url || defaults.webhookUrl,
+        webhookMethod: (webhook?.method as 'POST' | 'PUT') || defaults.webhookMethod,
+        webhookValidateServerCert: webhook?.config.validate_server_cert ?? defaults.webhookValidateServerCert,
+        webhookLogLevel: (webhook?.config.log_level as 'Info' | 'Debug' | 'Warn' | 'Error') || defaults.webhookLogLevel,
+        webhookAuthMode,
+        webhookApiKey: webhook?.config.apikey?.key || defaults.webhookApiKey,
+        webhookApiKeyHeader: webhook?.config.apikey?.header || defaults.webhookApiKeyHeader,
+        oidcClientId: webhook?.config.oidc?.client_id || defaults.oidcClientId,
+        oidcClientSecret: webhook?.config.oidc?.client_secret || defaults.oidcClientSecret,
+        oidcWellKnownUrl: webhook?.config.oidc?.well_known || defaults.oidcWellKnownUrl,
+    };
+}
+
+export function buildApiRaEstSettingsFromForm(values: RaAuthFormValues): ApiRaEstSettings {
+    const estSettings: ApiRaEstSettings = {
+        auth_mode: UI_TO_API_AUTH_MODE[values.authMode],
+    };
+
+    if (values.authMode === 'Client Certificate' || values.authMode === 'Client Certificate + Webhook') {
+        estSettings.client_certificate_settings = {
+            chain_level_validation: values.chainValidationLevel,
+            validation_cas: values.validationCaIds,
+            allow_expired: values.allowExpiredAuth,
+        };
+    }
+
+    if (values.authMode === 'External Webhook' || values.authMode === 'Client Certificate + Webhook') {
+        const config: ApiRaWebhookHttpClient = {
+            validate_server_cert: values.webhookValidateServerCert,
+            log_level: values.webhookLogLevel,
+            auth_mode: UI_TO_API_WEBHOOK_AUTH_MODE[values.webhookAuthMode],
+        };
+
+        if (values.webhookAuthMode === 'API Key') {
+            config.apikey = {
+                key: values.webhookApiKey,
+                header: values.webhookApiKeyHeader,
+            };
+        } else if (values.webhookAuthMode === 'OIDC') {
+            config.oidc = {
+                client_id: values.oidcClientId,
+                client_secret: values.oidcClientSecret,
+                well_known: values.oidcWellKnownUrl,
+            };
+        }
+
+        estSettings.external_webhook_settings = {
+            name: values.webhookName,
+            url: values.webhookUrl,
+            method: values.webhookMethod,
+            config,
+        };
+    }
+
+    return estSettings;
 }
 
 // --- API Functions ---
@@ -211,7 +333,7 @@ export async function deleteRaIntegration(raId: string, integrationKey: string):
     const currentRa = await fetchRaById(raId);
     
     // 2. Check if metadata and the key exist
-    if (!currentRa.metadata || !currentRa.metadata[integrationKey]) {
+    if (!currentRa.metadata?.[integrationKey]) {
         throw new Error("Integration key not found in RA metadata.");
     }
     

--- a/src/types/ra-auth.ts
+++ b/src/types/ra-auth.ts
@@ -1,0 +1,21 @@
+export type UiRaAuthMode = 'Client Certificate' | 'External Webhook' | 'Client Certificate + Webhook' | 'No Auth';
+
+export type UiWebhookAuthMode = 'No Auth' | 'OIDC' | 'API Key';
+
+export interface RaAuthFormValues {
+  authMode: UiRaAuthMode;
+  validationCaIds: string[];
+  allowExpiredAuth: boolean;
+  chainValidationLevel: number;
+  webhookName: string;
+  webhookUrl: string;
+  webhookMethod: 'POST' | 'PUT';
+  webhookValidateServerCert: boolean;
+  webhookLogLevel: 'Info' | 'Debug' | 'Warn' | 'Error';
+  webhookAuthMode: UiWebhookAuthMode;
+  webhookApiKey: string;
+  webhookApiKeyHeader: string;
+  oidcClientId: string;
+  oidcClientSecret: string;
+  oidcWellKnownUrl: string;
+}

--- a/storybook/component-inventory.md
+++ b/storybook/component-inventory.md
@@ -75,6 +75,7 @@ This is the curated list of UI building blocks that should be preferred before c
 | Issuance chain visualizer | `src/components/shared/IssuanceChainVisualizer.tsx` | Chain of trust and hierarchy presentation |
 | Certificate selector | `src/components/shared/CertificateSelectorModal.tsx` | Choosing certificates from the system |
 | CA selector | `src/components/shared/CaSelectorModal.tsx` | Choosing CAs from the system |
+| RA auth configuration section | `src/components/ra/RaAuthConfigurationSection.tsx` | Shared enrollment/re-enrollment auth mode, client cert, and webhook config UI |
 
 ## Shared modals and workflow components
 


### PR DESCRIPTION
This pull request adds a dedicated **Re-enrollment** authentication configuration flow in `Registration Authority` creation/editing, with support for `Client Certificate`, `External Webhook`, and combined auth modes. It then consolidates shared auth rendering and mapping logic through `RaAuthConfigurationSection` plus helper builders/hydrators to keep enrollment and re-enrollment behavior consistent while reducing duplication.

#### Re-enrollment Auth Flow
- Added a specific re-enrollment auth configuration path in `page.tsx,` including mode selection and context-specific `Validation CAs`, webhook settings, and auth details.
- Added payload support for re-enrollment `est_rfc7030_settings` so re-enrollment auth configuration is submitted independently from enrollment auth settings.
- Added edit-mode hydration for re-enrollment auth fields so existing RAs load re-enrollment auth configuration correctly.

#### Shared RA Auth Componentization
- Extracted duplicated enrollment/re-enrollment auth UI into `RaAuthConfigurationSection` in `RaAuthConfigurationSection.tsx`.
- Replaced inline duplicated auth sections in `page.tsx` with two configured component instances (enrollment and re-enrollment).
- Added reusable auth form models in `ra-auth.ts` to standardize mode and webhook form state.

#### Auth Mapping And API Helpers
- Added auth mapping constants in dms-api.ts: `UI_TO_API_AUTH_MODE`, `API_TO_UI_AUTH_MODE`, `UI_TO_API_WEBHOOK_AUTH_MODE`, and `API_TO_UI_WEBHOOK_AUTH_MODE`.
- Added helper functions in `dms-api.ts`: `createDefaultRaAuthFormValues`, `hydrateRaAuthFormValuesFromApi`, and `buildApiRaEstSettingsFromForm`.
- Updated metadata guard style in `deleteRaIntegration` to use optional chaining for cleaner null-safe checks.

#### Tests And Documentation
- Added focused tests in `dms-api.test.ts` for default auth values, hydration, API build output, and mode mapping constants.
- Updated webhook fixture shapes in `dms-api.test.ts` to align with typed `external_webhook_settings.config`.
- Documented the new reusable auth component in `component-inventory.md`.
