### PR TITLE
fix: migrate CA type filter from legacy to current type values

### DIFF
--- a/src/app/certificate-authorities/page.tsx
+++ b/src/app/certificate-authorities/page.tsx
@@ -69,8 +69,8 @@ const STATUS_OPTIONS: { value: CaStatusFilter; label: string }[] = [
 
 const TYPE_OPTIONS: { value: CaTypeFilter, label: string; icon: React.ElementType }[] = [
     { value: 'MANAGED', label: 'Managed', icon: Landmark },
-    { value: 'IMPORTED', label: 'Imported', icon: UploadCloud },
-    { value: 'EXTERNAL', label: 'External', icon: FileText },
+    { value: 'IMPORTED_WITH_KEY', label: 'Imported with Key', icon: UploadCloud },
+    { value: 'IMPORTED_WITHOUT_KEY', label: 'Imported without Key', icon: UploadCloud },
 ];
 
 

--- a/src/app/certificate-authorities/page.tsx
+++ b/src/app/certificate-authorities/page.tsx
@@ -69,8 +69,8 @@ const STATUS_OPTIONS: { value: CaStatusFilter; label: string }[] = [
 
 const TYPE_OPTIONS: { value: CaTypeFilter, label: string; icon: React.ElementType }[] = [
     { value: 'MANAGED', label: 'Managed', icon: Landmark },
-    { value: 'IMPORTED_WITH_KEY', label: 'Imported with Key', icon: UploadCloud },
-    { value: 'IMPORTED_WITHOUT_KEY', label: 'Imported without Key', icon: UploadCloud },
+    { value: 'IMPORTED_WITH_KEY', label: 'Imported with key', icon: UploadCloud },
+    { value: 'IMPORTED_WITHOUT_KEY', label: 'Imported without key', icon: UploadCloud },
 ];
 
 

--- a/src/lib/ca-utils.test.ts
+++ b/src/lib/ca-utils.test.ts
@@ -57,7 +57,7 @@ describe('ca-utils', () => {
         id: 'ca-2',
         name: 'Root CA Revoked',
         status: 'revoked' as CaStatusFilter,
-        caType: 'IMPORTED',
+        caType: 'IMPORTED_WITH_KEY',
         level: 0,
         children: [],
       }),
@@ -132,25 +132,35 @@ describe('ca-utils', () => {
       expect(result[0].caType).toBe('MANAGED')
     })
 
-    it('should filter by type - IMPORTED only', () => {
+    it('should filter by type - IMPORTED_WITH_KEY only', () => {
       const result = filterCaList(mockCaTree, {
-        selectedTypes: ['IMPORTED'],
+        selectedTypes: ['IMPORTED_WITH_KEY'],
       })
 
       expect(result).toHaveLength(1)
       expect(result[0].id).toBe('ca-2')
-      expect(result[0].caType).toBe('IMPORTED')
+      expect(result[0].caType).toBe('IMPORTED_WITH_KEY')
     })
 
-    it('should filter by type - EXTERNAL only (maps to EXTERNAL_PUBLIC)', () => {
-      const result = filterCaList(mockCaTree, {
-        selectedTypes: ['EXTERNAL'],
+    it('should filter by type - IMPORTED_WITHOUT_KEY only', () => {
+      const treeWithImportedNoKey = [
+        ...mockCaTree,
+        makeCa({
+          id: 'ca-4',
+          name: 'Imported No Key CA',
+          status: 'active' as CaStatusFilter,
+          caType: 'IMPORTED_WITHOUT_KEY',
+          level: 0,
+          children: [],
+        }),
+      ]
+      const result = filterCaList(treeWithImportedNoKey, {
+        selectedTypes: ['IMPORTED_WITHOUT_KEY'],
       })
 
       expect(result).toHaveLength(1)
-      expect(result[0].id).toBe('ca-3')
-      expect(result[0].caType).toBe('EXTERNAL_PUBLIC')
-      expect(result[0].children).toHaveLength(1)
+      expect(result[0].id).toBe('ca-4')
+      expect(result[0].caType).toBe('IMPORTED_WITHOUT_KEY')
     })
 
     it('should filter by text - case insensitive match', () => {
@@ -195,12 +205,12 @@ describe('ca-utils', () => {
 
     it('should combine multiple type filters with OR logic', () => {
       const result = filterCaList(mockCaTree, {
-        selectedTypes: ['MANAGED', 'IMPORTED'],
+        selectedTypes: ['MANAGED', 'IMPORTED_WITH_KEY'],
       })
 
       expect(result).toHaveLength(2)
       expect(result.some(ca => ca.caType === 'MANAGED')).toBe(true)
-      expect(result.some(ca => ca.caType === 'IMPORTED')).toBe(true)
+      expect(result.some(ca => ca.caType === 'IMPORTED_WITH_KEY')).toBe(true)
     })
 
     it('should combine text, status, and type filters with AND logic', () => {

--- a/src/lib/ca-utils.ts
+++ b/src/lib/ca-utils.ts
@@ -3,7 +3,7 @@
 import type { CA } from './ca-data';
 
 export type CaStatusFilter = 'active' | 'expired' | 'revoked' | 'unknown';
-export type CaTypeFilter = 'MANAGED' | 'IMPORTED' | 'EXTERNAL';
+export type CaTypeFilter = 'MANAGED' | 'IMPORTED_WITH_KEY' | 'IMPORTED_WITHOUT_KEY';
 
 interface CaFilterOptions {
   filterText?: string;
@@ -31,14 +31,8 @@ export function filterCaList(caList: CA[], options: CaFilterOptions): CA[] {
       // Determine if the current CA node itself matches the filters.
       const matchesStatus = selectedStatuses.length > 0 ? selectedStatuses.includes(ca.status) : true;
       
-      const matchesType = selectedTypes.length > 0 
-        ? selectedTypes.some(type => {
-            if (type === 'EXTERNAL') {
-              // The "External" filter should ONLY catch public-only CAs.
-              return ca.caType === 'EXTERNAL_PUBLIC';
-            }
-            return ca.caType === type;
-          })
+      const matchesType = selectedTypes.length > 0
+        ? selectedTypes.some(type => ca.caType === type)
         : true;
 
       const matchesText = filterText ? ca.name.toLowerCase().includes(filterText.toLowerCase()) : true;
@@ -52,5 +46,5 @@ export function filterCaList(caList: CA[], options: CaFilterOptions): CA[] {
 
       return null;
     })
-    .filter((ca): ca is CA => ca !== null);
+    .filter(Boolean) as CA[];
 }


### PR DESCRIPTION
## Summary

The CA certificates list page was filtering by legacy type values (`MANAGED`, `IMPORTED`, `EXTERNAL`) that no longer match the current CA type model (`MANAGED`, `IMPORTED_WITH_KEY`, `IMPORTED_WITHOUT_KEY`). As a result, selecting the "Imported" filter option produced no matches for CAs stored with the new type values.

## Changes

- **`src/lib/ca-utils.ts`**: Updated `CaTypeFilter` union type to current values; removed dead `EXTERNAL` branch from `filterCaList`, simplified to direct equality check.
- **`src/app/certificate-authorities/page.tsx`**: Replaced legacy `IMPORTED` and `EXTERNAL` entries in `TYPE_OPTIONS` with `IMPORTED_WITH_KEY` and `IMPORTED_WITHOUT_KEY`.
- **`src/lib/ca-utils.test.ts`**: Updated fixture `caType` and test cases to use the new type values.

Closes #168