### PR TITLE
refactor: enhance develop workflow by adding tag validation

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -5,28 +5,60 @@ on:
     branches:
       - develop
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Docker image tag (leave blank to use 'dev'). Cannot be 'latest' or start with a number."
+        required: false
+        default: ""
 
 jobs:
+  validate_tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.set_tag.outputs.tag }}
+    steps:
+      - name: Validate and set tag
+        id: set_tag
+        run: |
+          TAG="${{ github.event.inputs.tag }}"
+          TAG="${TAG:-dev}"
+
+          if [[ "${TAG,,}" == "latest" ]]; then
+            echo "Error: tag 'latest' is not allowed." >&2
+            exit 1
+          fi
+
+          if ! [[ "$TAG" =~ ^[A-Za-z_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "Error: tag must match ^[A-Za-z_][A-Za-z0-9_.-]{0,127}$ (got '$TAG')." >&2
+            exit 1
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
   dev_image:
     name: "Build DEV docker image"
+    needs: validate_tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Login to Github Registry
-        uses: docker/login-action@v3 
+        uses: docker/login-action@v3
         with:
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Build the Docker image latest tag
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build the Docker image
         uses: docker/build-push-action@v6
         with:
           push: true
           tags: |
-            ghcr.io/lamassuiot/lamassu-ui:${{ github.sha }}
-            ghcr.io/lamassuiot/lamassu-ui:dev
+            ghcr.io/lamassuiot/lamassu-ui:${{ needs.validate_tag.outputs.tag }}
+            ghcr.io/lamassuiot/lamassu-ui:${{ needs.validate_tag.outputs.tag }}-${{ github.sha }}

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -14,22 +14,24 @@ on:
 jobs:
   validate_tag:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       tag: ${{ steps.set_tag.outputs.tag }}
     steps:
       - name: Validate and set tag
         id: set_tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          TAG="${{ github.event.inputs.tag }}"
-          TAG="${TAG:-dev}"
+          TAG="${INPUT_TAG:-dev}"
 
           if [[ "${TAG,,}" == "latest" ]]; then
             echo "Error: tag 'latest' is not allowed." >&2
             exit 1
           fi
 
-          if ! [[ "$TAG" =~ ^[A-Za-z_][A-Za-z0-9_.-]{0,127}$ ]]; then
-            echo "Error: tag must match ^[A-Za-z_][A-Za-z0-9_.-]{0,127}$ (got '$TAG')." >&2
+          if ! [[ "$TAG" =~ ^[A-Za-z_][A-Za-z0-9_.-]{0,86}$ ]]; then
+            echo "Error: tag must match ^[A-Za-z_][A-Za-z0-9_.-]{0,86}$ (got '$TAG')." >&2
             exit 1
           fi
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building Docker images, adding support for custom image tags through workflow inputs and enforcing stricter validation rules to prevent invalid or unsafe tags.

**Workflow improvements:**

* Added a `tag` input to the `workflow_dispatch` trigger, allowing users to specify a custom Docker image tag when manually running the workflow. The tag cannot be `'latest'` or start with a number, and defaults to `'dev'` if left blank.
* Introduced a new `validate_tag` job that validates the provided tag using a regular expression and ensures it meets the required naming rules. The validated tag is then passed to subsequent jobs.

**Docker image build changes:**

* Updated the `dev_image` job to depend on `validate_tag`, and changed the Docker image tags to use the validated custom tag (and a tag that includes the commit SHA), instead of always using `'dev'` and the commit SHA.